### PR TITLE
feat(repository): Supabase 導入・PostgreSQL スキーマ設計（tenant_id 付与）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "task-flow",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.104.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
         "next": "16.2.2",
@@ -1286,6 +1287,92 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.1.tgz",
+      "integrity": "sha512-pqFnDKekq1isqlqnzqzyJ3mzmho+o+FjfVTqhKY3PFlwj2anx3OPznO1kbo1ZEwD8zg1r4EAFf/7pplLyX0ocQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.1.tgz",
+      "integrity": "sha512-JjAH4JN9rZzxh4plQnILPrQZXAG6ccoRS6z9hQAGmXpRSwJA+7CWbsDV2R82I8MROlGDsjqj1Ot/cWpTfdf6xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.1.tgz",
+      "integrity": "sha512-RqlLpvgXsjcc27fLyHNGm3zN0KDWXbkdTdaFtaEdX83RsTEqH7BAmshH7zoUMml5lL04naUeRjS3B81O6jZcJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.1.tgz",
+      "integrity": "sha512-dVJHhFB2ErBd0/2qE9G8CedCrGoAtBfL9Q4zbSMXO7b1Cpld916ljSiX21mURUqijPf1WoPQG4Bp/averUzk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.1.tgz",
+      "integrity": "sha512-2bQaLbkRshctkUVuqamwYZDEd+0cGSc9DY9sjh92DcA5hu1F/1AP8p6gxGr76sgdK9Ngi0rh+2Kdh+uC4hcnGA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.1.tgz",
+      "integrity": "sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.104.1",
+        "@supabase/functions-js": "2.104.1",
+        "@supabase/postgrest-js": "2.104.1",
+        "@supabase/realtime-js": "2.104.1",
+        "@supabase/storage-js": "2.104.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1665,7 +1752,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1697,6 +1783,15 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -4204,6 +4299,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -6756,7 +6860,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6979,6 +7082,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.104.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
     "next": "16.2.2",

--- a/src/lib/repository/factory.ts
+++ b/src/lib/repository/factory.ts
@@ -1,26 +1,16 @@
 import { DataProvider } from './types';
 import { mockProvider } from './mock-provider';
 
-// アクティブな DataProvider をモジュールスコープで保持する
-// setDataProvider() で実DB（Supabase など）への切り替えが可能
 let _provider: DataProvider = mockProvider;
 
-/**
- * 現在アクティブな DataProvider を返す。
- * アプリケーション全体でこの関数を通してプロバイダーを取得すること。
- */
 export function getDataProvider(): DataProvider {
   return _provider;
 }
 
 /**
  * DataProvider を差し替える。
- * 実DB への移行時や、テスト環境でのモック注入時に使用する。
- *
- * 例:
- *   import { setDataProvider } from '@/lib/repository/factory';
- *   import { SupabaseProvider } from '@/lib/repository/supabase-provider';
- *   setDataProvider(new SupabaseProvider());
+ * Supabase 移行時: setDataProvider(new SupabaseProvider(supabase))
+ * テスト時: setDataProvider(mockProvider)
  */
 export function setDataProvider(provider: DataProvider): void {
   _provider = provider;

--- a/src/lib/repository/types.ts
+++ b/src/lib/repository/types.ts
@@ -1,5 +1,6 @@
 export interface User {
   id: string;
+  tenant_id?: string;
   name: string;
   email: string;
   role: 'admin' | 'user';
@@ -15,6 +16,7 @@ export interface User {
 
 export interface OrganizationUnit {
   id: string;
+  tenant_id?: string;
   name: string;
   type: 'division' | 'group' | 'team' | 'root';
   parentId: string | null;
@@ -23,6 +25,7 @@ export interface OrganizationUnit {
 
 export interface UserChangeEvent {
   id: string;
+  tenant_id?: string;
   targetType: 'user' | 'unit';
   targetId: string;
   eventType: 'join' | 'transfer' | 'promotion' | 'leave' | 'retire' | 'unit_create' | 'unit_update' | 'unit_archive';
@@ -82,6 +85,7 @@ export interface AmountRule {
 
 export interface Category {
   id: string;
+  tenant_id?: string;
   name: string;
   parentId: string | null;
   targetDepartmentId: string;
@@ -110,6 +114,7 @@ export interface ApprovalStep {
 /** 代決（代理承認）設定 */
 export interface Delegation {
   id: string;
+  tenant_id?: string;
   delegatorId: string;  // 権限を委任する人
   delegateId: string;   // 代理で承認する人
   startDate: string;
@@ -120,6 +125,7 @@ export interface Delegation {
 
 export interface AuditLog {
   id: string;
+  tenant_id?: string;
   taskId: string;
   userId: string;
   userName?: string;
@@ -130,6 +136,7 @@ export interface AuditLog {
 
 export interface Task {
   id: string;
+  tenant_id?: string;
   title: string;
   description: string;
   requesterId: string;
@@ -153,12 +160,14 @@ export interface Task {
 
 export interface Status {
   id: string;
+  tenant_id?: string;
   label: string;
   color: string;
 }
 
 export interface Department {
   id: string;
+  tenant_id?: string;
   name: string;
 }
 

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary

- `@supabase/supabase-js` をインストール
- `src/lib/supabase/client.ts` を新規作成し Supabase クライアントを初期化
- 全 DB エンティティ型（`User`, `Task`, `Category`, `OrganizationUnit`, `AuditLog`, `UserChangeEvent`, `Delegation`, `Department`, `Status`）に `tenant_id?: string` を追加
- `.env.example` に `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` を定義
- `.gitignore` に `!.env.example` 例外を追加

Closes #4

## Test plan

- [ ] `npm run typecheck` がエラーなく通過すること
- [ ] `npm run lint` がエラーなく通過すること
- [ ] `src/lib/supabase/client.ts` が存在し、`createClient` を使用していること
- [ ] `.env.example` に Supabase 環境変数が定義されていること