### PR TITLE
chore(db): add initial PostgreSQL migration for multi-tenant schema (P0-3)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -62,9 +62,5 @@ jobs:
             --jq '.[] | select(.user.login == "github-actions[bot]") | .id' | \
             xargs -I{} gh api --method DELETE "repos/$REPO/issues/comments/{}" 2>/dev/null || true
 
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "## AI Code Review (Claude)
-
-$REVIEW_BODY
-
----
-*Powered by claude-sonnet-4-6*"
+          COMMENT_BODY=$(printf '## AI Code Review (Claude)\n\n%s\n\n---\n*Powered by claude-sonnet-4-6*' "$REVIEW_BODY")
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,36 @@
 @AGENTS.md
+
+# TaskFlow
+
+申請・承認ワークフロー管理アプリ。Next.js 16 + React 19 + TypeScript。
+
+## ディレクトリ構造
+
+```
+src/
+  app/          # Next.js App Router ページ
+  components/   # UIコンポーネント
+  context/      # React Context (auth, sidebar)
+  hooks/        # カスタムフック
+  lib/
+    repository/ # データプロバイダー抽象化（types.ts, factory.ts, mock-provider.ts）
+    export/     # CSV/JSONエクスポート
+    workflow-utils.ts  # 承認ルート解決ロジック
+  mocks/        # モックJSON（tasks.json, categories.json）
+```
+
+## 技術スタック
+
+- Next.js 16.2.2 / React 19.2.4
+- TypeScript 5 / Tailwind CSS 4
+- ESLint（React Compiler rules 適用）
+- モックデータのみ（DB未接続）
+
+## スクリプト
+
+```bash
+npm run dev        # 開発サーバー
+npm run typecheck  # 型チェック（tsc --noEmit）
+npm run lint       # ESLint
+npm run build      # プロダクションビルド
+```

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -84,3 +84,96 @@
 | バックエンド永続化 | Mock → Supabase 等の実DB へ移行 | ⬜ |
 | 通知システム | メール・システム内通知の強化 | ⬜ |
 | 監査ログの期間フィルタリング | admin 画面での詳細フィルター | ⬜ |
+
+---
+
+## 商用化ロードマップ
+
+### ステータス凡例（共通）
+- ✅ 完了 / 🔄 対応中 / ⬜ 未対応
+
+---
+
+### Phase 1 — バックエンド・認証基盤（P0）
+
+| # | 内容 | 対象ファイル | ステータス |
+|---|------|------------|----------|
+| P0-1 | Supabase 導入・PostgreSQL スキーマ設計（全テーブルに `tenant_id` 付与） | `src/lib/repository/types.ts`, `src/lib/repository/factory.ts` | ✅ |
+| P0-2 | `SupabaseDataProvider` 実装（`DataProvider` インターフェース継承） | `src/lib/repository/supabase-provider.ts`（新規） | ✅ |
+| P0-3 | DBマイグレーションファイル作成 | `supabase/migrations/001_initial_schema.sql`（新規） | ✅ |
+| P0-4 | 認証リプレース：`auth-context.tsx` を Supabase Auth + HTTP-Only Cookie に変更 | `src/context/auth-context.tsx`, `src/app/login/page.tsx` | ⬜ |
+| P0-5 | Next.js Middleware でサーバー側認証チェック追加 | `middleware.ts`（新規） | ⬜ |
+| P0-6 | Row Level Security (RLS) ポリシー設定（API レベル認可） | Supabase コンソール | ⬜ |
+| P0-7 | 入力バリデーション強化：`zod` 導入・`validateField()` 置き換え・ReDoS 対策 | `src/app/request/page.tsx` | ⬜ |
+| P0-8 | ファイルアップロード検証（最大10MB・許可拡張子リスト） | `src/app/request/page.tsx` | ✅ |
+
+---
+
+### Phase 2 — テスト基盤・CI/CD・エラーハンドリング（P1）
+
+| # | 内容 | 対象ファイル | ステータス |
+|---|------|------------|----------|
+| P1-1 | Vitest + React Testing Library + jest-dom 導入 | `package.json`, `vitest.config.ts`（新規） | ⬜ |
+| P1-2 | `workflow-utils.ts` ユニットテスト（`isMyTurn`, `resolveWorkflowTemplate` 境界値） | `src/lib/workflow-utils.test.ts`（新規） | ⬜ |
+| P1-3 | `mock-provider.ts` 統合テスト（`processApproval`, `createTask`） | `src/lib/repository/mock-provider.test.ts`（新規） | ⬜ |
+| P1-4 | Playwright E2E テスト（ログイン → 申請 → 承認 → 完了 の黄金パス） | `e2e/approval-flow.spec.ts`（新規） | ⬜ |
+| P1-5 | CI パイプライン拡充：`ci.yml` に build + test + `npm audit` を追加 | `.github/workflows/ci.yml` | ⬜ |
+| P1-6 | デプロイパイプライン作成（Vercel/Railway 自動デプロイ） | `.github/workflows/deploy.yml`（新規） | ⬜ |
+| P1-7 | `error.tsx` / `loading.tsx` を全ページに追加 | `src/app/error.tsx`, `src/app/loading.tsx`（新規） | ⬜ |
+| P1-8 | Toast 通知ライブラリ導入（`sonner` 推奨）・各ページの `console.error` を通知に置き換え | `src/app/inbox/page.tsx`, `src/app/tracker/page.tsx`, `src/app/admin/page.tsx` | ⬜ |
+
+---
+
+### Phase 3 — UX・品質向上（P2）
+
+| # | 内容 | 対象ファイル | ステータス |
+|---|------|------------|----------|
+| P2-1 | 全アイコンボタンに `aria-label` 付与・モーダル focus trap 実装 | 全ページ | ⬜ |
+| P2-2 | `<label>` と `<input>` の紐付け統一（date input 含む） | `src/app/request/page.tsx` 他 | ⬜ |
+| P2-3 | WCAG 2.1 AA カラーコントラスト確認・修正 | Tailwind CSS 設定 | ⬜ |
+| P2-4 | `next/dynamic` によるページ単位 Code Splitting | `src/app/admin/page.tsx`, `src/app/inbox/page.tsx` | ⬜ |
+| P2-5 | `OrgNode` 再帰描画に `React.memo` 適用 | `src/components/organization/org-node.tsx` | ⬜ |
+| P2-6 | `admin/page.tsx`（1,550行）・`inbox/page.tsx`（1,005行）をコンポーネント分割 | 上記2ファイル | ⬜ |
+| P2-7 | Sentry 導入（エラー監視・PII マスキング設定） | `sentry.client.config.ts`, `sentry.server.config.ts`（新規） | ⬜ |
+| P2-8 | Bundle サイズ分析 + Core Web Vitals 計測・改善（LCP < 2.5s 目標） | `next.config.ts` | ⬜ |
+
+---
+
+### Phase 4 — 機能追加（P2〜P3）
+
+| # | 内容 | 対象ファイル | ステータス |
+|---|------|------------|----------|
+| P2-9 | 通知システム（Supabase Realtime + SendGrid によるアプリ内・メール通知） | `src/app/api/notifications/`（新規） | ⬜ |
+| P2-10 | 監査ログの期間フィルタリング（admin 画面） | `src/app/admin/page.tsx` | ⬜ |
+| P2-11 | 金額ルール UI 実装（`AmountRule` スキーマは実装済み、UI が未実装） | `src/app/request/page.tsx` | ⬜ |
+| P2-12 | マルチテナント管理 UI（テナント作成・設定画面） | `src/app/admin/page.tsx` | ⬜ |
+| P2-13 | Excel（XLSX）出力対応 | `src/lib/export/`（新規ファイル追加） | ⬜ |
+| P2-14 | 外部連携用 REST API エンドポイント（BI ツール向け） | `src/app/api/`（新規） | ⬜ |
+| P3-1 | SAML/SSO 対応（Google Workspace, Microsoft Entra） | `src/context/auth-context.tsx` | ⬜ |
+| P3-2 | 承認ルート動的編集 UI（`updateApprovalRoute()` は実装済み、UI が未実装） | `src/app/inbox/page.tsx` | ⬜ |
+| P3-3 | i18n 対応（`next-intl` 導入・日本語 + 英語） | 全ページ | ⬜ |
+| P3-4 | レート制限・DDoS 対策（Vercel Edge / Cloudflare Workers） | `middleware.ts` | ⬜ |
+| P3-5 | GDPR 対応（ユーザーデータ削除 API・同意管理・PII マスキング） | `src/app/api/`（新規） | ⬜ |
+
+---
+
+### 推奨追加パッケージ
+
+```json
+{
+  "dependencies": {
+    "@supabase/supabase-js": "^2.x",
+    "zod": "^3.x",
+    "sonner": "^1.x",
+    "date-fns": "^3.x",
+    "@sentry/nextjs": "^8.x"
+  },
+  "devDependencies": {
+    "vitest": "^2.x",
+    "@testing-library/react": "^16.x",
+    "@testing-library/jest-dom": "^6.x",
+    "@playwright/test": "^1.x",
+    "@next/bundle-analyzer": "^16.x"
+  }
+}
+```

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,0 +1,182 @@
+-- TaskFlow initial schema
+-- Multi-tenant PostgreSQL schema for Supabase
+--
+-- Column naming follows TypeScript interface field names (camelCase quoted identifiers)
+-- to keep SupabaseDataProvider queries consistent with src/lib/repository/types.ts.
+-- tenant_id uses snake_case as it is the RLS partition key.
+
+-- ─── Extensions ──────────────────────────────────────────────────────────────
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ─── Tables ──────────────────────────────────────────────────────────────────
+
+CREATE TABLE departments (
+  id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  tenant_id   UUID NOT NULL,
+  name        TEXT NOT NULL
+);
+
+CREATE TABLE statuses (
+  id          TEXT PRIMARY KEY,
+  tenant_id   UUID NOT NULL,
+  label       TEXT NOT NULL,
+  color       TEXT NOT NULL
+);
+
+CREATE TABLE organization_units (
+  id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  tenant_id   UUID NOT NULL,
+  name        TEXT NOT NULL,
+  type        TEXT NOT NULL CHECK (type IN ('division', 'group', 'team', 'root')),
+  "parentId"  TEXT REFERENCES organization_units(id),
+  status      TEXT NOT NULL CHECK (status IN ('active', 'archived'))
+);
+
+CREATE TABLE users (
+  id               TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  tenant_id        UUID NOT NULL,
+  name             TEXT NOT NULL,
+  email            TEXT NOT NULL,
+  role             TEXT NOT NULL CHECK (role IN ('admin', 'user')),
+  "departmentId"   TEXT NOT NULL REFERENCES departments(id),
+  "orgUnitId"      TEXT NOT NULL REFERENCES organization_units(id),
+  "managerId"      TEXT REFERENCES users(id),
+  position         TEXT NOT NULL,
+  avatar           TEXT,
+  status           TEXT NOT NULL CHECK (status IN ('active', 'inactive', 'on_leave')),
+  "joinedAt"       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "leftAt"         TIMESTAMPTZ
+);
+
+CREATE TABLE categories (
+  id                    TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  tenant_id             UUID NOT NULL,
+  name                  TEXT NOT NULL,
+  "parentId"            TEXT REFERENCES categories(id),
+  "targetDepartmentId"  TEXT NOT NULL REFERENCES departments(id),
+  "slaDays"             INTEGER,
+  "customFields"        JSONB NOT NULL DEFAULT '[]',
+  "workflowTemplate"    JSONB NOT NULL DEFAULT '[]',
+  "amountRules"         JSONB NOT NULL DEFAULT '[]'
+);
+
+CREATE TABLE tasks (
+  id                    TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  tenant_id             UUID NOT NULL,
+  title                 TEXT NOT NULL,
+  description           TEXT NOT NULL DEFAULT '',
+  "requesterId"         TEXT NOT NULL REFERENCES users(id),
+  "targetDepartmentId"  TEXT NOT NULL REFERENCES departments(id),
+  "categoryId"          TEXT NOT NULL REFERENCES categories(id),
+  category              TEXT,
+  "statusId"            TEXT NOT NULL REFERENCES statuses(id),
+  status                TEXT NOT NULL CHECK (status IN ('todo', 'in_progress', 'completed')),
+  priority              TEXT NOT NULL CHECK (priority IN ('low', 'normal', 'high')) DEFAULT 'normal',
+  "createdAt"           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt"           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "dueDate"             TIMESTAMPTZ NOT NULL,
+  "approvalRoute"       JSONB NOT NULL DEFAULT '[]',
+  "ccRoute"             JSONB DEFAULT '[]',
+  "currentApproverId"   TEXT REFERENCES users(id),
+  "currentApproverName" TEXT,
+  "customData"          JSONB DEFAULT '{}',
+  "taskType"            TEXT CHECK ("taskType" IN ('approval', 'circulation')) DEFAULT 'approval'
+);
+
+CREATE TABLE audit_logs (
+  id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  tenant_id   UUID NOT NULL,
+  "taskId"    TEXT NOT NULL REFERENCES tasks(id),
+  "userId"    TEXT NOT NULL REFERENCES users(id),
+  "userName"  TEXT,
+  action      TEXT NOT NULL,
+  comment     TEXT,
+  timestamp   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE user_change_events (
+  id            TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  tenant_id     UUID NOT NULL,
+  "targetType"  TEXT NOT NULL CHECK ("targetType" IN ('user', 'unit')),
+  "targetId"    TEXT NOT NULL,
+  "eventType"   TEXT NOT NULL CHECK ("eventType" IN (
+                  'join', 'transfer', 'promotion', 'leave', 'retire',
+                  'unit_create', 'unit_update', 'unit_archive'
+                )),
+  "scheduledAt" TIMESTAMPTZ NOT NULL,
+  "appliedAt"   TIMESTAMPTZ,
+  status        TEXT NOT NULL CHECK (status IN ('pending', 'applied', 'cancelled')) DEFAULT 'pending',
+  changes       JSONB NOT NULL DEFAULT '{}',
+  note          TEXT
+);
+
+CREATE TABLE delegations (
+  id            TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  tenant_id     UUID NOT NULL,
+  "delegatorId" TEXT NOT NULL REFERENCES users(id),
+  "delegateId"  TEXT NOT NULL REFERENCES users(id),
+  "startDate"   TIMESTAMPTZ NOT NULL,
+  "endDate"     TIMESTAMPTZ,
+  reason        TEXT,
+  "isActive"    BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+-- ─── Row Level Security ──────────────────────────────────────────────────────
+
+ALTER TABLE departments        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE statuses           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE organization_units ENABLE ROW LEVEL SECURITY;
+ALTER TABLE users              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE categories         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tasks              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_logs         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_change_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE delegations        ENABLE ROW LEVEL SECURITY;
+
+-- Helper: read tenant_id from the authenticated user's JWT metadata
+CREATE OR REPLACE FUNCTION auth_tenant_id()
+RETURNS UUID
+LANGUAGE sql STABLE
+AS $$
+  SELECT (auth.jwt() -> 'user_metadata' ->> 'tenant_id')::UUID
+$$;
+
+-- Tenant isolation: each row is visible and writable only within its tenant
+CREATE POLICY tenant_isolation ON departments
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+CREATE POLICY tenant_isolation ON statuses
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+CREATE POLICY tenant_isolation ON organization_units
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+CREATE POLICY tenant_isolation ON users
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+CREATE POLICY tenant_isolation ON categories
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+CREATE POLICY tenant_isolation ON tasks
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+CREATE POLICY tenant_isolation ON audit_logs
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+CREATE POLICY tenant_isolation ON user_change_events
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+CREATE POLICY tenant_isolation ON delegations
+  FOR ALL USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+
+-- ─── Indexes ─────────────────────────────────────────────────────────────────
+
+CREATE INDEX ON tasks              (tenant_id, "statusId");
+CREATE INDEX ON tasks              (tenant_id, "requesterId");
+CREATE INDEX ON tasks              (tenant_id, "currentApproverId");
+CREATE INDEX ON tasks              (tenant_id, "createdAt" DESC);
+CREATE INDEX ON audit_logs         (tenant_id, "taskId");
+CREATE INDEX ON users              (tenant_id, email);
+CREATE INDEX ON user_change_events (tenant_id, status, "scheduledAt");
+CREATE INDEX ON delegations        (tenant_id, "delegatorId", "isActive");


### PR DESCRIPTION
## Summary

- 9テーブル（departments, statuses, organization_units, users, categories, tasks, audit_logs, user_change_events, delegations）の初期スキーマを追加
- 全テーブルに `tenant_id UUID NOT NULL` を付与してマルチテナント対応
- TypeScript インターフェースの camelCase フィールド名に合わせた quoted identifier を使用
- RLS（Row Level Security）を全テーブルに有効化し、`auth_tenant_id()` ヘルパー関数でテナント分離ポリシーを設定
- 8本のパフォーマンスインデックスを追加
- IMPROVEMENTS.md の P0-3 ステータスを ✅ に更新

Closes #8

## Test plan

- [ ] `supabase/migrations/001_initial_schema.sql` をローカルの Supabase インスタンスに適用してエラーなく完了すること
- [ ] 各テーブルに `tenant_id` が存在すること
- [ ] RLS ポリシーが有効になっていること
- [ ] typecheck・lint が通ること