### PR TITLE
feat(auth): replace mock auth with Supabase Auth + cookie session (P0-4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "task-flow",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.104.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
@@ -1344,6 +1345,18 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.2.tgz",
+      "integrity": "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.102.1"
+      }
+    },
     "node_modules/@supabase/storage-js": {
       "version": "2.104.1",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.1.tgz",
@@ -1362,6 +1375,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.1.tgz",
       "integrity": "sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.104.1",
         "@supabase/functions-js": "2.104.1",
@@ -2868,6 +2882,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.104.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,19 +1,51 @@
 'use client';
 
+import { useState } from 'react';
 import Image from 'next/image';
 import { useAuth } from '@/context/auth-context';
-import { User, Shield, Briefcase, Users, LayoutDashboard, Crown } from 'lucide-react';
+import { User, Shield, Briefcase, Users, LayoutDashboard, Crown, Loader2 } from 'lucide-react';
 
-const loginOptions = [
-  { id: 'user_president', name: '山田 太郎', role: 'President', label: '代表取締役 (社長)', icon: Crown, color: 'bg-amber-100 text-amber-700' },
-  { id: 'user_gm_sales_0', name: '高橋 健二', role: 'General Manager', label: '事業部長 (GM)', icon: Briefcase, color: 'bg-blue-100 text-blue-700' },
-  { id: 'user_tl_sales_0_0', name: '中村 浩', role: 'Team Leader', label: 'チームリーダー (TL)', icon: Users, color: 'bg-indigo-100 text-indigo-700' },
-  { id: 'user_m_v6ate0xjx', name: '渡辺 洋子', role: 'Member', label: '一般社員 (メンバー)', icon: User, color: 'bg-slate-100 text-slate-700' },
-  { id: 'user_admin_1', name: '佐藤 健二', role: 'General Manager', label: '管理部門 (Admin/受付側)', icon: Shield, color: 'bg-rose-100 text-rose-700' },
+const isMockMode = !process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+const demoUsers = [
+  { email: 'yamada.t@example.com', name: '山田 太郎', label: '代表取締役 (社長)', icon: Crown, color: 'bg-amber-100 text-amber-700' },
+  { email: 'sales.gm0@example.com', name: '高橋 健二', label: '事業部長 (GM)', icon: Briefcase, color: 'bg-blue-100 text-blue-700' },
+  { email: 'sales.tl00@example.com', name: '中村 浩', label: 'チームリーダー (TL)', icon: Users, color: 'bg-indigo-100 text-indigo-700' },
+  { email: 'sales.m000@example.com', name: '渡辺 洋子', label: '一般社員 (メンバー)', icon: User, color: 'bg-slate-100 text-slate-700' },
+  { email: 'kenji.sato@example.com', name: '佐藤 健二', label: '管理部門 (Admin/受付側)', icon: Shield, color: 'bg-rose-100 text-rose-700' },
 ];
 
 export default function LoginPage() {
   const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsSubmitting(true);
+    try {
+      await login(email, password || 'demo');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'ログインに失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDemoLogin = async (demoEmail: string) => {
+    setError('');
+    setIsSubmitting(true);
+    try {
+      await login(demoEmail, 'demo');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'ログインに失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <div className="min-h-screen grid lg:grid-cols-2">
@@ -52,40 +84,102 @@ export default function LoginPage() {
       </div>
 
       {/* Login Side */}
-      <div className="flex items-center justify-center p-8 bg-slate-50">
-        <div className="w-full max-w-md">
-          <div className="text-center mb-12">
+      <div className="flex items-center justify-center p-8 bg-slate-50 overflow-y-auto">
+        <div className="w-full max-w-md py-8">
+          <div className="text-center mb-8">
             <div className="lg:hidden flex items-center justify-center gap-2 mb-6">
               <div className="w-8 h-8 bg-slate-900 text-white rounded-lg flex items-center justify-center font-bold">TB</div>
               <span className="font-bold text-xl tracking-tight">Task Bridge</span>
             </div>
-            <h2 className="text-3xl font-bold text-slate-900 mb-2">ログイン選択</h2>
-            <p className="text-slate-500 font-medium">デモ環境用：ログインするロールを選択してください</p>
+            <h2 className="text-3xl font-bold text-slate-900 mb-2">ログイン</h2>
+            <p className="text-slate-500 font-medium">
+              {isMockMode ? 'デモ環境：メールアドレスでログイン' : 'メールアドレスとパスワードを入力してください'}
+            </p>
           </div>
 
-          <div className="space-y-3">
-            {loginOptions.map((option) => (
-              <button
-                key={option.id}
-                onClick={() => login(option.id)}
-                className="w-full flex items-center gap-4 p-4 bg-white border border-slate-200 rounded-2xl hover:border-slate-400 hover:shadow-xl hover:-translate-y-0.5 transition-all group text-left"
-              >
-                <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${option.color} group-hover:scale-110 transition-transform`}>
-                  <option.icon className="w-6 h-6" />
-                </div>
-                <div className="flex-1">
-                  <div className="text-xs font-bold text-slate-400 uppercase tracking-widest leading-none mb-1">{option.label}</div>
-                  <div className="text-lg font-bold text-slate-900">{option.name}</div>
-                </div>
-                <div className="w-8 h-8 rounded-full bg-slate-50 flex items-center justify-center group-hover:bg-slate-900 group-hover:text-white transition-colors">
-                  <LayoutDashboard className="w-4 h-4" />
-                </div>
-              </button>
-            ))}
-          </div>
+          {/* Email / Password Form */}
+          <form onSubmit={handleSubmit} className="space-y-4 mb-2">
+            <div>
+              <label htmlFor="email" className="block text-sm font-semibold text-slate-700 mb-1">
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                type="email"
+                required
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                placeholder="user@example.com"
+                className="w-full px-4 py-3 border border-slate-300 rounded-xl text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+              />
+            </div>
+            {!isMockMode && (
+              <div>
+                <label htmlFor="password" className="block text-sm font-semibold text-slate-700 mb-1">
+                  パスワード
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  required
+                  value={password}
+                  onChange={e => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  className="w-full px-4 py-3 border border-slate-300 rounded-xl text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                />
+              </div>
+            )}
+
+            {error && (
+              <p className="text-sm text-red-600 font-medium">{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full py-3 px-4 bg-slate-900 text-white font-bold rounded-xl hover:bg-slate-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {isSubmitting ? <Loader2 className="w-5 h-5 animate-spin" /> : null}
+              ログイン
+            </button>
+          </form>
+
+          {/* Demo quick-access (mock mode only) */}
+          {isMockMode && (
+            <>
+              <div className="my-6 flex items-center gap-3">
+                <div className="flex-1 h-px bg-slate-200" />
+                <span className="text-xs text-slate-400 font-bold uppercase tracking-widest whitespace-nowrap">デモ（ワンクリック）</span>
+                <div className="flex-1 h-px bg-slate-200" />
+              </div>
+
+              <div className="space-y-3">
+                {demoUsers.map((u) => (
+                  <button
+                    key={u.email}
+                    onClick={() => handleDemoLogin(u.email)}
+                    disabled={isSubmitting}
+                    className="w-full flex items-center gap-4 p-4 bg-white border border-slate-200 rounded-2xl hover:border-slate-400 hover:shadow-xl hover:-translate-y-0.5 transition-all group text-left disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${u.color} group-hover:scale-110 transition-transform`}>
+                      <u.icon className="w-6 h-6" />
+                    </div>
+                    <div className="flex-1">
+                      <div className="text-xs font-bold text-slate-400 uppercase tracking-widest leading-none mb-1">{u.label}</div>
+                      <div className="text-base font-bold text-slate-900">{u.name}</div>
+                      <div className="text-xs text-slate-400">{u.email}</div>
+                    </div>
+                    <div className="w-8 h-8 rounded-full bg-slate-50 flex items-center justify-center group-hover:bg-slate-900 group-hover:text-white transition-colors">
+                      <LayoutDashboard className="w-4 h-4" />
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
 
           <p className="mt-8 text-center text-xs text-slate-400 font-bold uppercase tracking-widest">
-            Future Integration: Microsoft 365 Azure AD
+            {isMockMode ? 'Mock Mode — No Database Connection' : 'Powered by Supabase Auth'}
           </p>
         </div>
       </div>

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 import { User, DataProvider } from '@/lib/repository/types';
 import { getDataProvider } from '@/lib/repository/factory';
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser';
 import { useRouter } from 'next/navigation';
 
 interface AuthContextType {
   user: User | null;
-  login: (userId: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<void>;
   logout: () => void;
   isLoading: boolean;
 }
@@ -20,36 +22,82 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
 
   useEffect(() => {
-    const initAuth = async () => {
-      const storedUserId = localStorage.getItem('task_bridge_user_id');
-      if (storedUserId) {
+    const supabase = getSupabaseBrowserClient();
+
+    if (!supabase) {
+      // Mock mode: restore session from localStorage
+      const initMockAuth = async () => {
+        const storedUserId = localStorage.getItem('task_bridge_user_id');
+        if (storedUserId) {
+          const provider = getDataProvider();
+          const p = provider as DataProvider & { setCurrentUser?: (id: string) => void };
+          p.setCurrentUser?.(storedUserId);
+          const currentUser = await provider.getCurrentUser();
+          setUser(currentUser);
+        }
+        setIsLoading(false);
+      };
+      initMockAuth();
+      return;
+    }
+
+    // Supabase mode: subscribe to auth state changes (session stored in cookies)
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (_event: AuthChangeEvent, session: Session | null) => {
+      if (session?.user?.email) {
         const provider = getDataProvider();
-        const p = provider as DataProvider & { setCurrentUser?: (id: string) => void };
-        p.setCurrentUser?.(storedUserId);
-        const currentUser = await provider.getCurrentUser();
-        setUser(currentUser);
+        const users = await provider.getUsers();
+        const matched = users.find(u => u.email === session.user!.email) ?? null;
+        setUser(matched);
+      } else {
+        setUser(null);
       }
       setIsLoading(false);
-    };
-    initAuth();
+    });
+
+    // Trigger initial session check
+    supabase.auth.getSession().then(({ data: { session } }: { data: { session: Session | null } }) => {
+      if (!session) setIsLoading(false);
+    });
+
+    return () => subscription.unsubscribe();
   }, []);
 
-  const login = async (userId: string) => {
-    const provider = getDataProvider();
-    const p = provider as DataProvider & { setCurrentUser?: (id: string) => void };
-    p.setCurrentUser?.(userId);
-    const currentUser = await provider.getCurrentUser();
-    if (currentUser) {
-      setUser(currentUser);
-      localStorage.setItem('task_bridge_user_id', userId);
+  const login = async (email: string, password: string) => {
+    const supabase = getSupabaseBrowserClient();
+
+    if (!supabase) {
+      // Mock mode: find user by email, password is ignored
+      const provider = getDataProvider();
+      const users = await provider.getUsers();
+      const matched = users.find(u => u.email === email);
+      if (!matched) throw new Error('ユーザーが見つかりません');
+      const p = provider as DataProvider & { setCurrentUser?: (id: string) => void };
+      p.setCurrentUser?.(matched.id);
+      setUser(matched);
+      localStorage.setItem('task_bridge_user_id', matched.id);
       router.push('/');
+      return;
     }
+
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) throw new Error(error.message);
+    router.push('/');
   };
 
   const logout = () => {
-    setUser(null);
-    localStorage.removeItem('task_bridge_user_id');
-    router.push('/login');
+    const supabase = getSupabaseBrowserClient();
+
+    if (!supabase) {
+      setUser(null);
+      localStorage.removeItem('task_bridge_user_id');
+      router.push('/login');
+      return;
+    }
+
+    supabase.auth.signOut().then(() => {
+      setUser(null);
+      router.push('/login');
+    });
   };
 
   return (

--- a/src/lib/supabase/browser.ts
+++ b/src/lib/supabase/browser.ts
@@ -1,0 +1,13 @@
+import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+let _client: SupabaseClient | null = null;
+
+export function getSupabaseBrowserClient(): SupabaseClient | null {
+  if (_client) return _client;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+  _client = createBrowserClient(url, key);
+  return _client;
+}


### PR DESCRIPTION
## Summary

- `@supabase/ssr` を導入し、`createBrowserClient` によるブラウザ用 Supabase クライアントを `src/lib/supabase/browser.ts` に追加
- `auth-context.tsx` をデュアルモード対応に刷新：Supabase Auth 利用時は cookie ベースのセッション管理、未設定時は既存の mock 動作にフォールバック
- `login/page.tsx` をメール/パスワードフォームに変更：mock モード時はデモユーザーのワンクリックログインボタンも表示
- `localStorage` への認証情報保存を Supabase モード時に廃止

Closes #3

## Test plan

- [ ] `npm run dev` で起動し、デモユーザーボタンをクリックしてログインできること
- [ ] メールアドレスを手入力してログインできること（mock モード：パスワード任意）
- [ ] ログアウト後に `/login` へリダイレクトされること
- [ ] `localStorage` に `task_bridge_user_id` が保存されていること（mock モード）
- [ ] `NEXT_PUBLIC_SUPABASE_URL` を設定した場合、デモボタンが非表示になりパスワードフィールドが表示されること