### PR TITLE
feat(auth): add Next.js Middleware for server-side auth guard (P0-5)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -2,7 +2,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
 
 jobs:

--- a/middleware.ts
+++ b/middleware.ts
@@ -27,7 +27,11 @@ export async function middleware(request: NextRequest) {
     },
   });
 
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error) {
+    // Supabase unavailable — fail open to avoid blocking all routes
+    return NextResponse.next();
+  }
 
   const { pathname } = request.nextUrl;
   const isLoginPage = pathname.startsWith('/login');
@@ -49,6 +53,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon\\.ico|api/|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,54 @@
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+
+export async function middleware(request: NextRequest) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  // Mock mode: no Supabase config — skip server-side auth check
+  if (!supabaseUrl || !supabaseKey) {
+    return NextResponse.next();
+  }
+
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(supabaseUrl, supabaseKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+        supabaseResponse = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) =>
+          supabaseResponse.cookies.set(name, value, options)
+        );
+      },
+    },
+  });
+
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const { pathname } = request.nextUrl;
+  const isLoginPage = pathname.startsWith('/login');
+
+  if (!user && !isLoginPage) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/login';
+    return NextResponse.redirect(url);
+  }
+
+  if (user && isLoginPage) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
## Summary

- `middleware.ts` を新規作成し、Next.js Middleware でサーバー側の認証チェックを実装
- `@supabase/ssr` の `createServerClient` で cookie ベースのセッションを読み取り
- 未認証ユーザーが保護ページにアクセスすると `/login` へリダイレクト
- 認証済みユーザーが `/login` にアクセスすると `/` へリダイレクト
- mock モード（Supabase env vars 未設定）では何もせず通過し、クライアント側認証に委譲

Closes #11

## Test plan

- [ ] mock モード（env vars 未設定）でアプリを起動し、既存の動作が変わらないこと
- [ ] `NEXT_PUBLIC_SUPABASE_URL` を設定した Supabase モードで、未認証で `/` にアクセスすると `/login` にリダイレクトされること
- [ ] Supabase モードで認証済みの状態で `/login` にアクセスすると `/` にリダイレクトされること
- [ ] `_next/static` などの静的アセットへのアクセスがリダイレクトされないこと