### PR TITLE
feat(rls): add explicit per-operation RLS policies and immutable audit_logs

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -102,7 +102,7 @@
 | P0-2 | `SupabaseDataProvider` 実装（`DataProvider` インターフェース継承） | `src/lib/repository/supabase-provider.ts`（新規） | ✅ |
 | P0-3 | DBマイグレーションファイル作成 | `supabase/migrations/001_initial_schema.sql`（新規） | ✅ |
 | P0-4 | 認証リプレース：`auth-context.tsx` を Supabase Auth + HTTP-Only Cookie に変更 | `src/context/auth-context.tsx`, `src/app/login/page.tsx` | ✅ |
-| P0-5 | Next.js Middleware でサーバー側認証チェック追加 | `middleware.ts`（新規） | ⬜ |
+| P0-5 | Next.js Middleware でサーバー側認証チェック追加 | `middleware.ts`（新規） | ✅ |
 | P0-6 | Row Level Security (RLS) ポリシー設定（API レベル認可） | Supabase コンソール | ⬜ |
 | P0-7 | 入力バリデーション強化：`zod` 導入・`validateField()` 置き換え・ReDoS 対策 | `src/app/request/page.tsx` | ⬜ |
 | P0-8 | ファイルアップロード検証（最大10MB・許可拡張子リスト） | `src/app/request/page.tsx` | ✅ |

--- a/supabase/migrations/002_rls_policies.sql
+++ b/supabase/migrations/002_rls_policies.sql
@@ -1,0 +1,118 @@
+-- TaskFlow RLS policy refinement
+-- Replaces the FOR ALL tenant_isolation policies from 001_initial_schema.sql
+-- with explicit per-operation policies. audit_logs has no UPDATE/DELETE policy
+-- to make audit records immutable.
+
+-- ─── departments ─────────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS tenant_isolation ON departments;
+
+CREATE POLICY "departments_select" ON departments
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "departments_insert" ON departments
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "departments_update" ON departments
+  FOR UPDATE USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "departments_delete" ON departments
+  FOR DELETE USING (tenant_id = auth_tenant_id());
+
+-- ─── statuses ────────────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS tenant_isolation ON statuses;
+
+CREATE POLICY "statuses_select" ON statuses
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "statuses_insert" ON statuses
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "statuses_update" ON statuses
+  FOR UPDATE USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "statuses_delete" ON statuses
+  FOR DELETE USING (tenant_id = auth_tenant_id());
+
+-- ─── organization_units ───────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS tenant_isolation ON organization_units;
+
+CREATE POLICY "organization_units_select" ON organization_units
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "organization_units_insert" ON organization_units
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "organization_units_update" ON organization_units
+  FOR UPDATE USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "organization_units_delete" ON organization_units
+  FOR DELETE USING (tenant_id = auth_tenant_id());
+
+-- ─── users ───────────────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS tenant_isolation ON users;
+
+CREATE POLICY "users_select" ON users
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "users_insert" ON users
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "users_update" ON users
+  FOR UPDATE USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "users_delete" ON users
+  FOR DELETE USING (tenant_id = auth_tenant_id());
+
+-- ─── categories ──────────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS tenant_isolation ON categories;
+
+CREATE POLICY "categories_select" ON categories
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "categories_insert" ON categories
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "categories_update" ON categories
+  FOR UPDATE USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "categories_delete" ON categories
+  FOR DELETE USING (tenant_id = auth_tenant_id());
+
+-- ─── tasks ───────────────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS tenant_isolation ON tasks;
+
+CREATE POLICY "tasks_select" ON tasks
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "tasks_insert" ON tasks
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "tasks_update" ON tasks
+  FOR UPDATE USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "tasks_delete" ON tasks
+  FOR DELETE USING (tenant_id = auth_tenant_id());
+
+-- ─── audit_logs ──────────────────────────────────────────────────────────────
+-- SELECT and INSERT only. No UPDATE or DELETE — audit records are immutable.
+
+DROP POLICY IF EXISTS tenant_isolation ON audit_logs;
+
+CREATE POLICY "audit_logs_select" ON audit_logs
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "audit_logs_insert" ON audit_logs
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+
+-- ─── user_change_events ───────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS tenant_isolation ON user_change_events;
+
+CREATE POLICY "user_change_events_select" ON user_change_events
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "user_change_events_insert" ON user_change_events
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "user_change_events_update" ON user_change_events
+  FOR UPDATE USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "user_change_events_delete" ON user_change_events
+  FOR DELETE USING (tenant_id = auth_tenant_id());
+
+-- ─── delegations ─────────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS tenant_isolation ON delegations;
+
+CREATE POLICY "delegations_select" ON delegations
+  FOR SELECT USING (tenant_id = auth_tenant_id());
+CREATE POLICY "delegations_insert" ON delegations
+  FOR INSERT WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "delegations_update" ON delegations
+  FOR UPDATE USING (tenant_id = auth_tenant_id()) WITH CHECK (tenant_id = auth_tenant_id());
+CREATE POLICY "delegations_delete" ON delegations
+  FOR DELETE USING (tenant_id = auth_tenant_id());


### PR DESCRIPTION
## Summary

- `001_initial_schema.sql` の `FOR ALL tenant_isolation` ポリシーを `DROP` し、SELECT / INSERT / UPDATE / DELETE の明示的な操作別ポリシーに置き換え
- `audit_logs` テーブルのみ UPDATE / DELETE ポリシーを設けず、監査ログの不変性を保証
- 全9テーブルに対して `auth_tenant_id()` によるテナント分離を適用

Closes #13

## Test plan

- [ ] Supabase コンソールで `002_rls_policies.sql` を実行し、各テーブルに操作別ポリシーが作成されていることを確認
- [ ] `authenticated` ロールで別テナントの JWT を使用してクエリを実行し、データが返らないことを確認
- [ ] `audit_logs` テーブルに対して UPDATE / DELETE を試み、RLS により拒否されることを確認
- [ ] `audit_logs` に INSERT が正常に成功することを確認