### PR TITLE
test(e2e): Playwright E2E golden path (login → request → approve → complete)

### DIFF
--- a/e2e/approval-flow.spec.ts
+++ b/e2e/approval-flow.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+const MEMBER_NAME = '渡辺 洋子';
+const ADMIN_NAME = '佐藤 健二';
+
+test('申請から承認・完了までの黄金パス', async ({ page }) => {
+  const TASK_TITLE = `E2E名刺申請 ${Date.now()}`;
+
+  // ── 0. 初期化：ストレージをクリア ──
+  await page.goto('/login');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+
+  // ── 1. 一般社員（渡辺 洋子）でログイン ──
+  await page.getByRole('button', { name: new RegExp(MEMBER_NAME) }).click();
+  await expect(page).not.toHaveURL(/login/);
+
+  // ── 2. 申請フォームへ移動 ──
+  await page.goto('/request');
+
+  // ── 3. カテゴリー選択（大分類：総務・庶務 → 中分類：名刺申請）──
+  await page.locator('select').first().selectOption('cat_ga');
+  await expect(page.locator('select').nth(1)).not.toBeDisabled();
+  await page.locator('select').nth(1).selectOption('cat_ga_meishi');
+
+  // ── 4. タイトル入力 ──
+  await page.getByPlaceholder('例：2026年度 資格取得祝金申請').fill(TASK_TITLE);
+
+  // ── 5. 名刺申請の必須カスタムフィールド入力 ──
+  // 役職（text, required）
+  await page.locator('#field-meishi_yakushoku input').fill('テスト役職');
+  // 名刺の枚数（select, required）
+  await page.locator('#field-meishi_count select').selectOption({ index: 1 });
+  // 受取方法（select, required）
+  await page.locator('#field-meishi_receive select').selectOption({ index: 1 });
+
+  // ── 6. 申請送信 ──
+  await page.getByRole('button', { name: '申請を送信する' }).click();
+
+  // ── 7. トラッカーへリダイレクトされ、申請が表示されることを確認 ──
+  await expect(page).toHaveURL('/tracker');
+  await expect(page.getByText(TASK_TITLE)).toBeVisible();
+
+  // ── 8. ユーザー切替：管理部門（佐藤 健二）でログイン ──
+  // 認証情報のみ削除（モックデータ tb_state は保持する）
+  await page.evaluate(() => localStorage.removeItem('task_bridge_user_id'));
+  await page.goto('/login');
+  await page.getByRole('button', { name: new RegExp(ADMIN_NAME) }).click();
+  await expect(page).not.toHaveURL(/login/);
+
+  // ── 9. 受信トレイへ移動・申請を検索して選択 ──
+  await page.goto('/inbox');
+  await page.getByPlaceholder('依頼を検索...').fill(TASK_TITLE);
+  await page.locator('button', { hasText: TASK_TITLE }).first().click();
+
+  // ── 10. 承認 ──
+  await expect(page.getByRole('button', { name: '承認・受理する' })).toBeVisible();
+  await page.getByRole('button', { name: '承認・受理する' }).click();
+
+  // fetchTasks の完了を待つ
+  await page.waitForTimeout(1000);
+
+  // ── 11. タスクを再選択してステータスを更新 ──
+  await page.locator('button', { hasText: TASK_TITLE }).first().click();
+
+  // ── 12. タスクが「完了」になったことを確認 ──
+  await expect(page.getByRole('button', { name: '再利用して申請' })).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1912,6 +1913,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -7478,6 +7496,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
@@ -24,6 +25,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});


### PR DESCRIPTION
## Summary

- `@playwright/test@^1.59.1` を devDependencies に追加
- `playwright.config.ts` を新規作成（chromium、baseURL=localhost:3000、webServer=npm run dev）
- `e2e/approval-flow.spec.ts` を新規作成：申請 → 承認 → 完了の黄金パスE2Eテスト
  - 渡辺 洋子（一般社員）でログイン → 名刺申請カテゴリで申請送信
  - 佐藤 健二（管理部門）でログイン → 受信トレイで承認
  - タスクが「完了」ステータスになることを確認
- `package.json` に `test:e2e` スクリプトを追加

Closes #23

## Test plan

- [ ] `npm run typecheck` がエラーなし
- [ ] `npm run lint` がエラーなし
- [ ] ローカル開発サーバー起動後に `npm run test:e2e` でE2Eテストが通ること