### PR TITLE
feat(app): error.tsx / loading.tsx を全ページに追加

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+
+export default function Error({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <div className="flex flex-col items-center gap-4 max-w-md">
+        <div className="flex items-center justify-center w-16 h-16 rounded-full bg-red-50">
+          <AlertTriangle className="w-8 h-8 text-red-500" />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <h2 className="text-xl font-semibold text-foreground">
+            エラーが発生しました
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {error.message || 'ページの読み込み中に問題が発生しました。'}
+          </p>
+          {error.digest && (
+            <p className="text-xs text-muted-foreground font-mono mt-1">
+              エラーID: {error.digest}
+            </p>
+          )}
+        </div>
+
+        <button
+          onClick={() => unstable_retry()}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+        >
+          <RotateCcw className="w-4 h-4" />
+          再試行
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -26,7 +26,9 @@ export default function Error({
             エラーが発生しました
           </h2>
           <p className="text-sm text-muted-foreground">
-            {error.message || 'ページの読み込み中に問題が発生しました。'}
+            {process.env.NODE_ENV === 'development'
+              ? (error.message || 'ページの読み込み中に問題が発生しました。')
+              : 'ページの読み込み中に問題が発生しました。'}
           </p>
           {error.digest && (
             <p className="text-xs text-muted-foreground font-mono mt-1">
@@ -36,7 +38,8 @@ export default function Error({
         </div>
 
         <button
-          onClick={() => unstable_retry()}
+          type="button"
+          onClick={unstable_retry}
           className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
         >
           <RotateCcw className="w-4 h-4" />

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,32 @@
+export default function Loading() {
+  return (
+    <div className="flex flex-col gap-6 p-6 animate-pulse">
+      {/* ページヘッダースケルトン */}
+      <div className="flex flex-col gap-2">
+        <div className="h-7 w-48 rounded-md bg-muted" />
+        <div className="h-4 w-72 rounded-md bg-muted" />
+      </div>
+
+      {/* カードグリッドスケルトン */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-3 p-4 rounded-lg border border-border bg-background"
+          >
+            <div className="flex items-center justify-between">
+              <div className="h-4 w-24 rounded-md bg-muted" />
+              <div className="h-6 w-16 rounded-full bg-muted" />
+            </div>
+            <div className="h-4 w-full rounded-md bg-muted" />
+            <div className="h-4 w-3/4 rounded-md bg-muted" />
+            <div className="flex items-center gap-2 mt-2">
+              <div className="h-6 w-6 rounded-full bg-muted" />
+              <div className="h-3 w-20 rounded-md bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `src/app/error.tsx` を追加（Next.js 16 の `unstable_retry` API を使用した Error Boundary）
- `src/app/loading.tsx` を追加（Suspense フォールバック用カードスケルトン UI）
- エラー時は AlertTriangle アイコン・エラーメッセージ・digest ID・再試行ボタンを表示
- ローディング時はアニメーション付きスケルトンカードを表示

Closes #27

## Test plan

- [ ] 開発サーバーで各ページにアクセスし、ローディング中にスケルトン UI が表示されること
- [ ] エラー境界が機能し、エラー発生時に白画面でなくエラー UI が表示されること
- [ ] 「再試行」ボタンクリックで `unstable_retry()` が呼ばれページが再レンダリングされること
- [ ] typecheck・lint が通過すること（CI 確認）