### PR TITLE
feat(toast): sonner 導入・console.error を Toast 通知に置き換え（P1-8）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
+        "sonner": "^1.7.4",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
       },
@@ -8273,6 +8274,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
+    "sonner": "^1.7.4",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -31,6 +31,7 @@ import { Task, AuditLog, Category, Delegation } from '@/lib/repository/types';
 import { useAuth } from '@/context/auth-context';
 import { ClientOnlyDate } from '@/components/common/client-only-date';
 import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
 
 export default function RequestInbox() {
   const { user } = useAuth();
@@ -180,6 +181,7 @@ export default function RequestInbox() {
       const newLogs = await provider.getAuditLogs(selectedTask.id);
       setLogs(newLogs);
     } catch (error) {
+      toast.error('承認処理に失敗しました');
       console.error('Approval failed:', error);
     } finally {
       setIsProcessing(false);
@@ -197,6 +199,7 @@ export default function RequestInbox() {
       const newLogs = await provider.getAuditLogs(selectedTask.id);
       setLogs(newLogs);
     } catch (error) {
+      toast.error('確認処理に失敗しました');
       console.error('Acknowledge failed:', error);
     } finally {
       setIsProcessing(false);
@@ -221,6 +224,7 @@ export default function RequestInbox() {
       setShowRejectModal(false);
       setRejectComment('');
     } catch (error) {
+      toast.error('差し戻し処理に失敗しました');
       console.error('Rejection failed:', error);
     } finally {
       setIsProcessing(false);
@@ -245,6 +249,7 @@ export default function RequestInbox() {
       setShowChangeApproverModal(false);
       setChangingStepIndex(null);
     } catch (error) {
+      toast.error('承認者の変更に失敗しました');
       console.error('Change approver failed:', error);
     }
   };

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -180,6 +180,7 @@ export default function RequestInbox() {
       await fetchTasks();
       const newLogs = await provider.getAuditLogs(selectedTask.id);
       setLogs(newLogs);
+      toast.success('承認しました');
     } catch (error) {
       toast.error('承認処理に失敗しました');
       console.error('Approval failed:', error);
@@ -198,6 +199,7 @@ export default function RequestInbox() {
       await fetchTasks();
       const newLogs = await provider.getAuditLogs(selectedTask.id);
       setLogs(newLogs);
+      toast.success('確認しました');
     } catch (error) {
       toast.error('確認処理に失敗しました');
       console.error('Acknowledge failed:', error);
@@ -223,6 +225,7 @@ export default function RequestInbox() {
       setLogs(newLogs);
       setShowRejectModal(false);
       setRejectComment('');
+      toast.success('差し戻しました');
     } catch (error) {
       toast.error('差し戻し処理に失敗しました');
       console.error('Rejection failed:', error);
@@ -248,6 +251,7 @@ export default function RequestInbox() {
       setLogs(newLogs);
       setShowChangeApproverModal(false);
       setChangingStepIndex(null);
+      toast.success('承認者を変更しました');
     } catch (error) {
       toast.error('承認者の変更に失敗しました');
       console.error('Change approver failed:', error);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { AppContent } from "@/components/layout/app-content";
+import { Toaster } from "sonner";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -26,6 +27,7 @@ export default function RootLayout({
           メインコンテンツへスキップ
         </a>
         <AppContent>{children}</AppContent>
+        <Toaster richColors position="top-right" />
       </body>
     </html>
   );

--- a/src/app/organization/page.tsx
+++ b/src/app/organization/page.tsx
@@ -18,6 +18,7 @@ import { getDataProvider } from '@/lib/repository/factory';
 import { User, OrganizationUnit } from '@/lib/repository/types';
 import { OrgNode } from '@/components/organization/org-node';
 import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
 
 export default function OrganizationPage() {
   const [units, setUnits] = useState<OrganizationUnit[]>([]);
@@ -46,6 +47,7 @@ export default function OrganizationPage() {
         setUnits(allUnits);
         setUsers(allUsers);
       } catch (error) {
+        toast.error('組織データの取得に失敗しました');
         console.error('Failed to fetch organization data:', error);
       } finally {
         setIsLoading(false);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,6 +73,7 @@ export default function Dashboard() {
     try {
       await provider.processApproval(taskId, user.id, 'approve', 'ダッシュボードからのクイック承認');
       await fetchData();
+      toast.success('承認しました');
     } catch (error) {
       toast.error('承認処理に失敗しました');
       console.error('Approval failed:', error);
@@ -85,6 +86,7 @@ export default function Dashboard() {
     try {
       await provider.processApproval(taskId, user.id, 'reject', 'ダッシュボードからのクイック差戻し');
       await fetchData();
+      toast.success('差し戻しました');
     } catch (error) {
       toast.error('差し戻し処理に失敗しました');
       console.error('Rejection failed:', error);
@@ -103,6 +105,7 @@ export default function Dashboard() {
       );
       setSelectedTaskIds(new Set());
       await fetchData();
+      toast.success('一括承認しました');
     } catch (error) {
       toast.error('一括承認処理に失敗しました');
       console.error('Bulk approval failed:', error);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '@/context/auth-context';
 import Link from 'next/link';
 import { OrgNode } from '@/components/organization/org-node';
 import { ClientOnlyDate } from '@/components/common/client-only-date';
+import { toast } from 'sonner';
 
 export default function Dashboard() {
   const { user } = useAuth();
@@ -73,6 +74,7 @@ export default function Dashboard() {
       await provider.processApproval(taskId, user.id, 'approve', 'ダッシュボードからのクイック承認');
       await fetchData();
     } catch (error) {
+      toast.error('承認処理に失敗しました');
       console.error('Approval failed:', error);
     }
   };
@@ -84,6 +86,7 @@ export default function Dashboard() {
       await provider.processApproval(taskId, user.id, 'reject', 'ダッシュボードからのクイック差戻し');
       await fetchData();
     } catch (error) {
+      toast.error('差し戻し処理に失敗しました');
       console.error('Rejection failed:', error);
     }
   };
@@ -101,6 +104,7 @@ export default function Dashboard() {
       setSelectedTaskIds(new Set());
       await fetchData();
     } catch (error) {
+      toast.error('一括承認処理に失敗しました');
       console.error('Bulk approval failed:', error);
     } finally {
       setIsBulkApproving(false);


### PR DESCRIPTION
## Summary

- `sonner` ライブラリ（v1.x）を導入し `layout.tsx` に `<Toaster richColors position="top-right" />` を設置
- `src/app/inbox/page.tsx` — 承認・確認・差し戻し・承認者変更の4箇所を `toast.error` に置き換え
- `src/app/page.tsx` — ダッシュボードの承認・差し戻し・一括承認の3箇所を `toast.error` に置き換え
- `src/app/organization/page.tsx` — データ取得失敗の1箇所を `toast.error` に置き換え

Closes #29

## Test plan

- [ ] 各ページでエラーが発生したとき右上に Toast が表示されること
- [ ] `<Toaster />` が二重設置されていないこと
- [ ] typecheck・lint が pass すること