### PR TITLE
feat(a11y): 全アイコンボタン aria-label 付与・全モーダル focus trap 実装（P2-1）

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -30,6 +30,7 @@ import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import { ClientOnlyDate } from '@/components/common/client-only-date';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 
 export default function AdminSettings() {
   const [activeTab, setActiveTab] = useState<'general' | 'org' | 'categories' | 'security' | 'logs' | 'delegation'>('general');
@@ -112,6 +113,20 @@ export default function AdminSettings() {
   const [catFormAmountRules, setCatFormAmountRules] = useState<AmountRule[]>([]);
   const [catFormFields, setCatFormFields] = useState<CustomField[]>([]);
   const [catFormWorkflow, setCatFormWorkflow] = useState<WorkflowStepTemplate[]>([]);
+
+  // focus trap refs for each modal
+  const changeModalRef = useRef<HTMLDivElement>(null);
+  const delegationModalRef = useRef<HTMLDivElement>(null);
+  const addUserModalRef = useRef<HTMLDivElement>(null);
+  const catModalRef = useRef<HTMLDivElement>(null);
+  const editUserModalRef = useRef<HTMLDivElement>(null);
+  const unitModalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(changeModalRef, isChangeModalOpen, () => setIsChangeModalOpen(false));
+  useFocusTrap(delegationModalRef, showAddDelegationModal, () => setShowAddDelegationModal(false));
+  useFocusTrap(addUserModalRef, showAddUserModal, () => setShowAddUserModal(false));
+  useFocusTrap(catModalRef, showAddCatModal || editingCategory !== null, () => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); });
+  useFocusTrap(editUserModalRef, showEditUserModal, () => { setShowEditUserModal(false); setEditingUser(null); });
+  useFocusTrap(unitModalRef, showAddUnitModal || editingUnit !== null, () => { setShowAddUnitModal(false); setEditingUnit(null); });
 
   const fetchData = useCallback(async () => {
     const provider = getDataProvider();
@@ -833,11 +848,17 @@ export default function AdminSettings() {
               {/* 代決追加モーダル */}
               {showAddDelegationModal && (
                 <div className="fixed inset-0 z-[60] flex items-center justify-center p-8">
-                  <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowAddDelegationModal(false)} />
-                  <div className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300">
+                  <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowAddDelegationModal(false)} aria-hidden="true" />
+                  <div
+                    ref={delegationModalRef}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="delegation-modal-title"
+                    className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300"
+                  >
                     <div className="p-6 border-b flex items-center justify-between">
-                      <h3 className="text-lg font-bold text-[#191714]">代決設定を追加</h3>
-                      <button onClick={() => setShowAddDelegationModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
+                      <h3 id="delegation-modal-title" className="text-lg font-bold text-[#191714]">代決設定を追加</h3>
+                      <button type="button" onClick={() => setShowAddDelegationModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
                         <X className="w-5 h-5 text-slate-400" />
                       </button>
                     </div>
@@ -1010,13 +1031,20 @@ export default function AdminSettings() {
 
       {isChangeModalOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm animate-in fade-in duration-300">
-          <div className="bg-white w-full max-w-lg rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0" onClick={() => setIsChangeModalOpen(false)} aria-hidden="true" />
+          <div
+            ref={changeModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="change-modal-title"
+            className="relative bg-white w-full max-w-lg rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between bg-slate-50/50">
               <div>
-                <h3 className="text-xl font-bold text-[#191714]">人事・組織変更の登録</h3>
+                <h3 id="change-modal-title" className="text-xl font-bold text-[#191714]">人事・組織変更の登録</h3>
                 <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-1">Schedule Personnel Event</p>
               </div>
-              <button onClick={() => setIsChangeModalOpen(false)} className="p-2 hover:bg-slate-200 rounded-xl transition-colors">
+              <button type="button" onClick={() => setIsChangeModalOpen(false)} className="p-2 hover:bg-slate-200 rounded-xl transition-colors" aria-label="閉じる">
                 <ChevronRight className="w-5 h-5 rotate-90" />
               </button>
             </div>
@@ -1142,10 +1170,17 @@ export default function AdminSettings() {
       {/* 新規ユーザー追加モーダル */}
       {showAddUserModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm animate-in fade-in duration-300">
-          <div className="bg-white w-full max-w-md rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0" onClick={() => setShowAddUserModal(false)} aria-hidden="true" />
+          <div
+            ref={addUserModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="add-user-modal-title"
+            className="relative bg-white w-full max-w-md rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between">
-              <h3 className="text-lg font-bold text-[#191714]">メンバー新規追加</h3>
-              <button onClick={() => setShowAddUserModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors"><X className="w-5 h-5 text-slate-400" /></button>
+              <h3 id="add-user-modal-title" className="text-lg font-bold text-[#191714]">メンバー新規追加</h3>
+              <button type="button" onClick={() => setShowAddUserModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-400" /></button>
             </div>
             <div className="p-6 space-y-4">
               {[
@@ -1185,10 +1220,17 @@ export default function AdminSettings() {
       {/* カテゴリー追加・編集モーダル */}
       {(showAddCatModal || editingCategory) && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm animate-in fade-in duration-300">
-          <div className="bg-white w-full max-w-lg rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300 flex flex-col max-h-[90vh]">
+          <div className="absolute inset-0" onClick={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }} aria-hidden="true" />
+          <div
+            ref={catModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="cat-modal-title"
+            className="relative bg-white w-full max-w-lg rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300 flex flex-col max-h-[90vh]"
+          >
             <div className="p-6 border-b flex items-center justify-between shrink-0">
-              <h3 className="text-lg font-bold text-[#191714]">{editingCategory ? 'カテゴリーを編集' : 'カテゴリーを追加'}</h3>
-              <button onClick={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors"><X className="w-5 h-5 text-slate-400" /></button>
+              <h3 id="cat-modal-title" className="text-lg font-bold text-[#191714]">{editingCategory ? 'カテゴリーを編集' : 'カテゴリーを追加'}</h3>
+              <button type="button" onClick={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-400" /></button>
             </div>
 
             {/* タブ */}
@@ -1422,10 +1464,17 @@ export default function AdminSettings() {
       {/* ユーザー編集モーダル */}
       {showEditUserModal && editingUser && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm animate-in fade-in duration-300">
-          <div className="bg-white w-full max-w-md rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0" onClick={() => { setShowEditUserModal(false); setEditingUser(null); }} aria-hidden="true" />
+          <div
+            ref={editUserModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="edit-user-modal-title"
+            className="relative bg-white w-full max-w-md rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between">
-              <h3 className="text-lg font-bold text-[#191714]">プロフィール編集</h3>
-              <button onClick={() => { setShowEditUserModal(false); setEditingUser(null); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors"><X className="w-5 h-5 text-slate-400" /></button>
+              <h3 id="edit-user-modal-title" className="text-lg font-bold text-[#191714]">プロフィール編集</h3>
+              <button type="button" onClick={() => { setShowEditUserModal(false); setEditingUser(null); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-400" /></button>
             </div>
             <div className="p-6 space-y-4">
               {[
@@ -1485,10 +1534,17 @@ export default function AdminSettings() {
       {/* 組織ユニット追加・編集モーダル */}
       {(showAddUnitModal || editingUnit) && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm animate-in fade-in duration-300">
-          <div className="bg-white w-full max-w-md rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0" onClick={() => { setShowAddUnitModal(false); setEditingUnit(null); }} aria-hidden="true" />
+          <div
+            ref={unitModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="unit-modal-title"
+            className="relative bg-white w-full max-w-md rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between">
-              <h3 className="text-lg font-bold text-[#191714]">{editingUnit ? 'ユニットを編集' : 'ユニットを追加'}</h3>
-              <button onClick={() => { setShowAddUnitModal(false); setEditingUnit(null); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors"><X className="w-5 h-5 text-slate-400" /></button>
+              <h3 id="unit-modal-title" className="text-lg font-bold text-[#191714]">{editingUnit ? 'ユニットを編集' : 'ユニットを追加'}</h3>
+              <button type="button" onClick={() => { setShowAddUnitModal(false); setEditingUnit(null); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-400" /></button>
             </div>
             <div className="p-6 space-y-4">
               <div className="space-y-1">

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import Image from 'next/image';
 import {
   Search,
@@ -32,6 +32,7 @@ import { useAuth } from '@/context/auth-context';
 import { ClientOnlyDate } from '@/components/common/client-only-date';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 
 export default function RequestInbox() {
   const { user } = useAuth();
@@ -57,6 +58,11 @@ export default function RequestInbox() {
   const [approverSearchQuery, setApproverSearchQuery] = useState('');
   const [delegations, setDelegations] = useState<Delegation[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
+
+  const rejectModalRef = useRef<HTMLDivElement>(null);
+  const changeApproverModalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(rejectModalRef, showRejectModal, () => setShowRejectModal(false));
+  useFocusTrap(changeApproverModalRef, showChangeApproverModal, () => setShowChangeApproverModal(false));
 
   const now = new Date('2026-04-02T09:05:57Z'); // For consistent testing matching current metadata
 
@@ -508,11 +514,17 @@ export default function RequestInbox() {
       {/* 差し戻しモーダル */}
       {showRejectModal && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center p-8">
-          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowRejectModal(false)} />
-          <div className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowRejectModal(false)} aria-hidden="true" />
+          <div
+            ref={rejectModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="reject-modal-title"
+            className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between">
-              <h3 className="text-lg font-bold text-[#191714]">差し戻し理由を入力</h3>
-              <button onClick={() => setShowRejectModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors">
+              <h3 id="reject-modal-title" className="text-lg font-bold text-[#191714]">差し戻し理由を入力</h3>
+              <button type="button" onClick={() => setShowRejectModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
                 <X className="w-5 h-5 text-slate-400" />
               </button>
             </div>
@@ -568,11 +580,17 @@ export default function RequestInbox() {
       {/* 承認者変更モーダル */}
       {showChangeApproverModal && changingStepIndex !== null && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center p-8">
-          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowChangeApproverModal(false)} />
-          <div className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowChangeApproverModal(false)} aria-hidden="true" />
+          <div
+            ref={changeApproverModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="change-approver-modal-title"
+            className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between">
-              <h3 className="text-lg font-bold text-[#191714]">承認者を変更</h3>
-              <button onClick={() => setShowChangeApproverModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors">
+              <h3 id="change-approver-modal-title" className="text-lg font-bold text-[#191714]">承認者を変更</h3>
+              <button type="button" onClick={() => setShowChangeApproverModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
                 <X className="w-5 h-5 text-slate-400" />
               </button>
             </div>

--- a/src/app/organization/page.tsx
+++ b/src/app/organization/page.tsx
@@ -19,6 +19,7 @@ import { User, OrganizationUnit } from '@/lib/repository/types';
 import { OrgNode } from '@/components/organization/org-node';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 
 export default function OrganizationPage() {
   const [units, setUnits] = useState<OrganizationUnit[]>([]);
@@ -29,6 +30,8 @@ export default function OrganizationPage() {
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [showProfileModal, setShowProfileModal] = useState(false);
+  const profileModalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(profileModalRef, showProfileModal, () => setShowProfileModal(false));
 
   const handleSearchChange = (value: string) => {
     setSearchQuery(value);
@@ -153,9 +156,11 @@ export default function OrganizationPage() {
           <aside className="lg:col-span-4 animate-in slide-in-from-right-8 duration-500 sticky top-8 h-fit">
             <div className="bg-slate-900 rounded-[32px] overflow-hidden shadow-2xl text-white">
               <div className="relative h-32 bg-gradient-to-br from-slate-800 to-slate-900">
-                <button 
+                <button
+                  type="button"
                   onClick={() => setSelectedUser(null)}
                   className="absolute top-6 right-6 p-2 bg-white/10 hover:bg-white/20 rounded-full transition-all backdrop-blur-md"
+                  aria-label="パネルを閉じる"
                 >
                   <X className="w-4 h-4 text-white" />
                 </button>
@@ -234,11 +239,17 @@ export default function OrganizationPage() {
       {/* プロフィール詳細モーダル */}
       {showProfileModal && selectedUser && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center p-8">
-          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowProfileModal(false)} />
-          <div className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowProfileModal(false)} aria-hidden="true" />
+          <div
+            ref={profileModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="profile-modal-title"
+            className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between">
-              <h3 className="text-lg font-bold text-[#191714]">プロフィール詳細</h3>
-              <button onClick={() => setShowProfileModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors">
+              <h3 id="profile-modal-title" className="text-lg font-bold text-[#191714]">プロフィール詳細</h3>
+              <button type="button" onClick={() => setShowProfileModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
                 <X className="w-5 h-5 text-slate-400" />
               </button>
             </div>

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -23,6 +23,7 @@ import { Category, User, ApprovalStep, AmountRule, CustomField, FieldValidation 
 import { resolveWorkflowTemplate } from '@/lib/workflow-utils';
 import { useAuth } from '@/context/auth-context';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 
 const DRAFTS_KEY = 'task_bridge_drafts';
 const MAX_DRAFTS = 5;
@@ -116,6 +117,11 @@ function RequestFormContent() {
   const [searchResults, setSearchResults] = useState<User[]>([]);
 
   const [allUsers, setAllUsers] = useState<User[]>([]);
+
+  const draftListModalRef = useRef<HTMLDivElement>(null);
+  const searchModalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(draftListModalRef, showDraftList, () => setShowDraftList(false));
+  useFocusTrap(searchModalRef, showSearch, () => setShowSearch(false));
 
   useEffect(() => {
     const fetchInitial = async () => {
@@ -967,11 +973,17 @@ function RequestFormContent() {
       {/* C-1: 下書き一覧モーダル */}
       {showDraftList && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center p-8">
-          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowDraftList(false)} />
-          <div className="relative w-full max-w-lg bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowDraftList(false)} aria-hidden="true" />
+          <div
+            ref={draftListModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="draft-list-modal-title"
+            className="relative w-full max-w-lg bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between">
-              <h3 className="text-lg font-bold text-[#191714]">保存済み下書き</h3>
-              <button onClick={() => setShowDraftList(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors">
+              <h3 id="draft-list-modal-title" className="text-lg font-bold text-[#191714]">保存済み下書き</h3>
+              <button type="button" onClick={() => setShowDraftList(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
                 <X className="w-5 h-5 text-slate-400" />
               </button>
             </div>
@@ -1017,14 +1029,20 @@ function RequestFormContent() {
       {/* Search Modal */}
       {showSearch && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center p-8">
-          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowSearch(false)} />
-          <div className="relative w-full max-w-lg bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowSearch(false)} aria-hidden="true" />
+          <div
+            ref={searchModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="search-modal-title"
+            className="relative w-full max-w-lg bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b">
               <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-bold text-[#191714]">
+                <h3 id="search-modal-title" className="text-lg font-bold text-[#191714]">
                   {searchMode === 'approver' ? '承認者の検索・追加' : 'CC（共有先）の検索・追加'}
                 </h3>
-                <button onClick={() => setShowSearch(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors">
+                <button type="button" onClick={() => setShowSearch(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
                   <X className="w-5 h-5 text-slate-400" />
                 </button>
               </div>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef } from 'react';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 import Image from 'next/image';
 import { Bell, HelpCircle, User, Search, ChevronRight, LogOut, Settings, X, BookOpen, MessageCircle, Menu } from 'lucide-react';
 import { useAuth } from '@/context/auth-context';
@@ -16,6 +17,8 @@ export function Header() {
   const [showNotifPanel, setShowNotifPanel] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const helpModalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(helpModalRef, showHelpModal, () => setShowHelpModal(false));
 
   const handleMouseEnter = () => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
@@ -183,16 +186,22 @@ export function Header() {
       {/* ヘルプモーダル */}
       {showHelpModal && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center p-8">
-          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowHelpModal(false)} />
-          <div className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300">
+          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onClick={() => setShowHelpModal(false)} aria-hidden="true" />
+          <div
+            ref={helpModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="help-modal-title"
+            className="relative w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300"
+          >
             <div className="p-6 border-b flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <div className="w-9 h-9 rounded-xl bg-blue-50 flex items-center justify-center text-blue-600">
                   <HelpCircle className="w-5 h-5" />
                 </div>
-                <h3 className="text-lg font-bold text-[#191714]">ヘルプ・よくある質問</h3>
+                <h3 id="help-modal-title" className="text-lg font-bold text-[#191714]">ヘルプ・よくある質問</h3>
               </div>
-              <button onClick={() => setShowHelpModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors">
+              <button type="button" onClick={() => setShowHelpModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
                 <X className="w-5 h-5 text-slate-400" />
               </button>
             </div>

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -21,6 +21,10 @@ export function useFocusTrap(
 ) {
   useEffect(() => {
     if (!active || !ref.current) return;
+
+    // モーダルを開く前にフォーカスしていた要素を記憶
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
     const container = ref.current;
     const focusable = Array.from(
       container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS),
@@ -54,6 +58,10 @@ export function useFocusTrap(
     };
 
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      // モーダルを閉じたらトリガー要素にフォーカスを戻す
+      previouslyFocused?.focus();
+    };
   }, [active, ref, onEscape]);
 }


### PR DESCRIPTION
## Summary

- `useFocusTrap` フックにフォーカス復元機能を追加（モーダルを閉じたときトリガー要素にフォーカスが戻る）
- `header.tsx`・`inbox/page.tsx`・`organization/page.tsx`・`request/page.tsx`・`admin/page.tsx` の全11モーダルに `role="dialog"`、`aria-modal="true"`、`aria-labelledby` を追加
- 全モーダルに `useFocusTrap` を適用（Tab/Shift+Tab フォーカスがモーダル内に閉じる）
- モーダルの X ボタンに `aria-label="閉じる"` と `type="button"` を追加
- organization/page.tsx のサイドパネル X ボタンにも `aria-label="パネルを閉じる"` を追加
- バックドロップ overlay div に `aria-hidden="true"` を追加

Closes #31

## Test plan

- [ ] 各モーダルを開き、Tab キーでフォーカスがモーダル内を循環することを確認
- [ ] Escape キーでモーダルが閉じることを確認
- [ ] モーダルを閉じたとき開いたボタンにフォーカスが戻ることを確認
- [ ] スクリーンリーダー（NVDA/VoiceOver）でモーダルタイトルが読み上げられることを確認
- [ ] typecheck・lint が pass すること