### PR TITLE
feat(a11y): label と input の紐付け統一（date input 含む）

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -478,8 +478,9 @@ export default function AdminSettings() {
                 )}
                 <div className="grid grid-cols-2 gap-8 pt-4">
                   <div className="space-y-2">
-                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">テナント名</label>
+                    <label htmlFor="admin-tenant-name" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">テナント名</label>
                     <input
+                      id="admin-tenant-name"
                       type="text"
                       value={tenantName}
                       onChange={(e) => setTenantName(e.target.value)}
@@ -864,8 +865,9 @@ export default function AdminSettings() {
                     </div>
                     <div className="p-6 space-y-4">
                       <div className="space-y-1">
-                        <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">権限を委任する人（不在者）<span className="text-rose-500">*</span></label>
+                        <label htmlFor="del-delegator" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">権限を委任する人（不在者）<span className="text-rose-500">*</span></label>
                         <select
+                          id="del-delegator"
                           className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all"
                           value={delDelegatorId}
                           onChange={e => setDelDelegatorId(e.target.value)}
@@ -877,8 +879,9 @@ export default function AdminSettings() {
                         </select>
                       </div>
                       <div className="space-y-1">
-                        <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">代理承認者<span className="text-rose-500">*</span></label>
+                        <label htmlFor="del-delegate" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">代理承認者<span className="text-rose-500">*</span></label>
                         <select
+                          id="del-delegate"
                           className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all"
                           value={delDelegateId}
                           onChange={e => setDelDelegateId(e.target.value)}
@@ -891,17 +894,17 @@ export default function AdminSettings() {
                       </div>
                       <div className="grid grid-cols-2 gap-3">
                         <div className="space-y-1">
-                          <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">開始日<span className="text-rose-500">*</span></label>
-                          <input type="date" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delStartDate} onChange={e => setDelStartDate(e.target.value)} />
+                          <label htmlFor="del-start-date" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">開始日<span className="text-rose-500">*</span></label>
+                          <input id="del-start-date" type="date" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delStartDate} onChange={e => setDelStartDate(e.target.value)} />
                         </div>
                         <div className="space-y-1">
-                          <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">終了日（任意）</label>
-                          <input type="date" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delEndDate} onChange={e => setDelEndDate(e.target.value)} />
+                          <label htmlFor="del-end-date" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">終了日（任意）</label>
+                          <input id="del-end-date" type="date" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delEndDate} onChange={e => setDelEndDate(e.target.value)} />
                         </div>
                       </div>
                       <div className="space-y-1">
-                        <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">理由・備考</label>
-                        <input type="text" placeholder="例：出張、育休など" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delReason} onChange={e => setDelReason(e.target.value)} />
+                        <label htmlFor="del-reason" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">理由・備考</label>
+                        <input id="del-reason" type="text" placeholder="例：出張、育休など" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delReason} onChange={e => setDelReason(e.target.value)} />
                       </div>
                       <div className="flex gap-3 pt-2">
                         <button onClick={() => setShowAddDelegationModal(false)} className="flex-1 py-3 bg-white border border-slate-200 text-slate-600 rounded-2xl font-bold text-sm hover:bg-slate-50 transition-all">キャンセル</button>
@@ -939,6 +942,7 @@ export default function AdminSettings() {
                       <Search className="w-4 h-4 text-slate-400 absolute left-3 top-1/2 -translate-y-1/2" />
                       <input
                         type="text"
+                        aria-label="監査ログを検索"
                         placeholder="ユーザー名、アクション種別で検索..."
                         value={logSearchQuery}
                         onChange={(e) => setLogSearchQuery(e.target.value)}
@@ -949,6 +953,7 @@ export default function AdminSettings() {
                       <CalendarDays className="w-4 h-4 text-slate-400" />
                       <input
                         type="date"
+                        aria-label="開始日"
                         value={logStartDate}
                         onChange={(e) => setLogStartDate(e.target.value)}
                         className="text-xs font-bold bg-slate-50 border border-slate-200 rounded-xl px-3 py-2 focus:outline-none focus:border-slate-400 transition-all"
@@ -956,6 +961,7 @@ export default function AdminSettings() {
                       <span className="text-slate-300 font-bold text-xs">~</span>
                       <input
                         type="date"
+                        aria-label="終了日"
                         value={logEndDate}
                         onChange={(e) => setLogEndDate(e.target.value)}
                         className="text-xs font-bold bg-slate-50 border border-slate-200 rounded-xl px-3 py-2 focus:outline-none focus:border-slate-400 transition-all"
@@ -1051,9 +1057,10 @@ export default function AdminSettings() {
             
             <div className="p-8 space-y-6 max-h-[70vh] overflow-y-auto">
               <div className="space-y-2">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">対象ユーザー</label>
-                <select 
-                  value={selectedUser} 
+                <label htmlFor="change-target-user" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">対象ユーザー</label>
+                <select
+                  id="change-target-user"
+                  value={selectedUser}
                   onChange={(e) => setSelectedUser(e.target.value)}
                   className="w-full h-12 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all"
                 >
@@ -1066,9 +1073,10 @@ export default function AdminSettings() {
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">変更種別</label>
-                  <select 
-                    value={changeType} 
+                  <label htmlFor="change-type-select" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">変更種別</label>
+                  <select
+                    id="change-type-select"
+                    value={changeType}
                     onChange={(e) => setChangeType(e.target.value as typeof changeType)}
                     className="w-full h-12 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all"
                   >
@@ -1079,9 +1087,9 @@ export default function AdminSettings() {
                   </select>
                 </div>
                 <div className="space-y-2">
-                  <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">適用予定日</label>
+                  <label htmlFor="change-scheduled-date" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">適用予定日</label>
                   <div className="relative">
-                    <input type="date" className="w-full h-12 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all pl-10" />
+                    <input id="change-scheduled-date" type="date" className="w-full h-12 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all pl-10" />
                     <CalendarDays className="w-4 h-4 absolute left-4 top-4 text-slate-400" />
                   </div>
                 </div>
@@ -1090,8 +1098,9 @@ export default function AdminSettings() {
               {(changeType === 'transfer' || changeType === 'promotion') && (
                 <div className="space-y-4 pt-4 border-t border-dashed">
                   <div className="space-y-2">
-                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">新所属組織</label>
-                    <select 
+                    <label htmlFor="change-new-org" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">新所属組織</label>
+                    <select
+                      id="change-new-org"
                       value={newOrgUnit}
                       onChange={(e) => setNewOrgUnit(e.target.value)}
                       className="w-full h-12 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all"
@@ -1103,8 +1112,9 @@ export default function AdminSettings() {
                     </select>
                   </div>
                   <div className="space-y-2">
-                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">新直属上長</label>
-                    <select 
+                    <label htmlFor="change-new-manager" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">新直属上長</label>
+                    <select
+                      id="change-new-manager"
                       value={newManager}
                       onChange={(e) => setNewManager(e.target.value)}
                       className="w-full h-12 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all"
@@ -1184,25 +1194,25 @@ export default function AdminSettings() {
             </div>
             <div className="p-6 space-y-4">
               {[
-                { label: '氏名', value: newUserName, setter: setNewUserName, placeholder: '例: 田中 太郎' },
-                { label: 'メールアドレス', value: newUserEmail, setter: setNewUserEmail, placeholder: 'example@company.co.jp' },
-              ].map(({ label, value, setter, placeholder }) => (
+                { id: 'new-user-name', label: '氏名', value: newUserName, setter: setNewUserName, placeholder: '例: 田中 太郎' },
+                { id: 'new-user-email', label: 'メールアドレス', value: newUserEmail, setter: setNewUserEmail, placeholder: 'example@company.co.jp' },
+              ].map(({ id, label, value, setter, placeholder }) => (
                 <div key={label} className="space-y-1">
-                  <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">{label}</label>
-                  <input type="text" value={value} onChange={e => setter(e.target.value)} placeholder={placeholder}
+                  <label htmlFor={id} className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">{label}</label>
+                  <input id={id} type="text" value={value} onChange={e => setter(e.target.value)} placeholder={placeholder}
                     className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
                 </div>
               ))}
               <div className="space-y-1">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">役職</label>
-                <select value={newUserPosition} onChange={e => setNewUserPosition(e.target.value)}
+                <label htmlFor="new-user-position" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">役職</label>
+                <select id="new-user-position" value={newUserPosition} onChange={e => setNewUserPosition(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   {['President', 'Division Manager', 'General Manager', 'Team Leader', 'Member'].map(p => <option key={p} value={p}>{p}</option>)}
                 </select>
               </div>
               <div className="space-y-1">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">組織ユニット</label>
-                <select value={newUserOrgUnit} onChange={e => setNewUserOrgUnit(e.target.value)}
+                <label htmlFor="new-user-org-unit" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">組織ユニット</label>
+                <select id="new-user-org-unit" value={newUserOrgUnit} onChange={e => setNewUserOrgUnit(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   <option value="">選択してください</option>
                   {orgUnits.map(u => <option key={u.id} value={u.id}>{u.name}</option>)}
@@ -1253,21 +1263,21 @@ export default function AdminSettings() {
               {catFormTab === 'basic' && (
                 <div className="space-y-4">
                   <div className="space-y-1">
-                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">カテゴリー名</label>
-                    <input type="text" value={catFormName} onChange={e => setCatFormName(e.target.value)} placeholder="例: 資格取得祝金申請"
+                    <label htmlFor="cat-name" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">カテゴリー名</label>
+                    <input id="cat-name" type="text" value={catFormName} onChange={e => setCatFormName(e.target.value)} placeholder="例: 資格取得祝金申請"
                       className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
                   </div>
                   <div className="space-y-1">
-                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">大分類（親カテゴリー）</label>
-                    <select value={catFormParentId} onChange={e => setCatFormParentId(e.target.value)}
+                    <label htmlFor="cat-parent" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">大分類（親カテゴリー）</label>
+                    <select id="cat-parent" value={catFormParentId} onChange={e => setCatFormParentId(e.target.value)}
                       className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                       <option value="">なし（大分類として追加）</option>
                       {categories.filter(c => c.parentId === null).map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
                     </select>
                   </div>
                   <div className="space-y-1">
-                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">目標SLA（営業日）</label>
-                    <input type="number" min={1} max={90} value={catFormSla} onChange={e => setCatFormSla(Number(e.target.value))}
+                    <label htmlFor="cat-sla" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">目標SLA（営業日）</label>
+                    <input id="cat-sla" type="number" min={1} max={90} value={catFormSla} onChange={e => setCatFormSla(Number(e.target.value))}
                       className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
                   </div>
                   <div className="space-y-2 pt-2 border-t border-dashed border-slate-100">
@@ -1322,10 +1332,10 @@ export default function AdminSettings() {
                   {catFormFields.map((field, idx) => (
                     <div key={field.id} className="p-3 bg-slate-50 border rounded-2xl space-y-2">
                       <div className="flex gap-2 items-center">
-                        <input type="text" placeholder="項目名（例: 受験料）" value={field.label}
+                        <input type="text" aria-label="項目名" placeholder="項目名（例: 受験料）" value={field.label}
                           onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, label: e.target.value } : f))}
                           className="flex-1 h-8 px-3 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
-                        <select value={field.type}
+                        <select aria-label="項目タイプ" value={field.type}
                           onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, type: e.target.value as CustomField['type'], options: undefined } : f))}
                           className="h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
                           <option value="text">テキスト</option>
@@ -1346,13 +1356,13 @@ export default function AdminSettings() {
                           <Trash2 className="w-3.5 h-3.5" />
                         </button>
                       </div>
-                      <input type="text" placeholder="プレースホルダー（任意）" value={field.placeholder ?? ''}
+                      <input type="text" aria-label="プレースホルダー" placeholder="プレースホルダー（任意）" value={field.placeholder ?? ''}
                         onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, placeholder: e.target.value } : f))}
                         className="w-full h-7 px-3 bg-white border rounded-xl text-[11px] text-slate-500 focus:outline-none focus:border-slate-400 transition-all" />
                       {field.type === 'select' && (
                         <div className="space-y-1">
                           <p className="text-[10px] text-slate-400 font-bold">選択肢（改行区切り）</p>
-                          <textarea rows={3} value={(field.options ?? []).join('\n')}
+                          <textarea rows={3} aria-label="選択肢（改行区切り）" value={(field.options ?? []).join('\n')}
                             onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, options: e.target.value.split('\n').filter(Boolean) } : f))}
                             className="w-full px-3 py-2 bg-white border rounded-xl text-xs focus:outline-none focus:border-slate-400 transition-all resize-none" />
                         </div>
@@ -1378,7 +1388,7 @@ export default function AdminSettings() {
                     <div key={step.id} className="p-3 bg-slate-50 border rounded-2xl space-y-2">
                       <div className="flex gap-2 items-center">
                         <span className="text-[10px] font-black text-slate-400 w-5 shrink-0">{idx + 1}</span>
-                        <input type="text" placeholder="ステップ名（例: 上長承認）" value={step.label}
+                        <input type="text" aria-label="ステップ名" placeholder="ステップ名（例: 上長承認）" value={step.label}
                           onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, label: e.target.value } : s))}
                           className="flex-1 h-8 px-3 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
                         <button type="button" onClick={() => setCatFormWorkflow(prev => prev.filter((_, i) => i !== idx))}
@@ -1387,7 +1397,7 @@ export default function AdminSettings() {
                         </button>
                       </div>
                       <div className="flex gap-2">
-                        <select value={step.approverType}
+                        <select aria-label="承認者タイプ" value={step.approverType}
                           onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, approverType: e.target.value as ApproverType, approverUserId: undefined, approverRole: undefined, approverGroupIds: undefined } : s))}
                           className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
                           <option value="direct_manager">直属上長</option>
@@ -1398,7 +1408,7 @@ export default function AdminSettings() {
                           <option value="approval_group">承認グループ</option>
                         </select>
                         {step.approverType === 'role' && (
-                          <select value={step.approverRole ?? ''}
+                          <select aria-label="役職" value={step.approverRole ?? ''}
                             onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, approverRole: e.target.value } : s))}
                             className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
                             <option value="">役職を選択</option>
@@ -1408,7 +1418,7 @@ export default function AdminSettings() {
                           </select>
                         )}
                         {step.approverType === 'specific_user' && (
-                          <select value={step.approverUserId ?? ''}
+                          <select aria-label="特定ユーザー" value={step.approverUserId ?? ''}
                             onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, approverUserId: e.target.value } : s))}
                             className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
                             <option value="">ユーザーを選択</option>
@@ -1416,7 +1426,7 @@ export default function AdminSettings() {
                           </select>
                         )}
                         {step.approverType === 'approval_group' && (
-                          <select value={step.parallelType ?? 'or'}
+                          <select aria-label="並列設定" value={step.parallelType ?? 'or'}
                             onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, parallelType: e.target.value as 'or' | 'and' } : s))}
                             className="h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
                             <option value="or">OR（誰か1名）</option>
@@ -1478,25 +1488,25 @@ export default function AdminSettings() {
             </div>
             <div className="p-6 space-y-4">
               {[
-                { label: '氏名', value: editUserName, setter: setEditUserName, placeholder: '例: 田中 太郎' },
-                { label: 'メールアドレス', value: editUserEmail, setter: setEditUserEmail, placeholder: 'example@company.co.jp' },
-              ].map(({ label, value, setter, placeholder }) => (
+                { id: 'edit-user-name', label: '氏名', value: editUserName, setter: setEditUserName, placeholder: '例: 田中 太郎' },
+                { id: 'edit-user-email', label: 'メールアドレス', value: editUserEmail, setter: setEditUserEmail, placeholder: 'example@company.co.jp' },
+              ].map(({ id, label, value, setter, placeholder }) => (
                 <div key={label} className="space-y-1">
-                  <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">{label}</label>
-                  <input type="text" value={value} onChange={e => setter(e.target.value)} placeholder={placeholder}
+                  <label htmlFor={id} className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">{label}</label>
+                  <input id={id} type="text" value={value} onChange={e => setter(e.target.value)} placeholder={placeholder}
                     className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
                 </div>
               ))}
               <div className="space-y-1">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">役職</label>
-                <select value={editUserPosition} onChange={e => setEditUserPosition(e.target.value)}
+                <label htmlFor="edit-user-position" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">役職</label>
+                <select id="edit-user-position" value={editUserPosition} onChange={e => setEditUserPosition(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   {['President', 'Division Manager', 'General Manager', 'Team Leader', 'Member'].map(p => <option key={p} value={p}>{p}</option>)}
                 </select>
               </div>
               <div className="space-y-1">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">組織ユニット</label>
-                <select value={editUserOrgUnit} onChange={e => setEditUserOrgUnit(e.target.value)}
+                <label htmlFor="edit-user-org-unit" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">組織ユニット</label>
+                <select id="edit-user-org-unit" value={editUserOrgUnit} onChange={e => setEditUserOrgUnit(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   {orgUnits.map(u => <option key={u.id} value={u.id}>{u.name}</option>)}
                 </select>
@@ -1548,13 +1558,13 @@ export default function AdminSettings() {
             </div>
             <div className="p-6 space-y-4">
               <div className="space-y-1">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">ユニット名</label>
-                <input type="text" value={unitFormName} onChange={e => setUnitFormName(e.target.value)} placeholder="例: 営業第一グループ"
+                <label htmlFor="unit-name" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">ユニット名</label>
+                <input id="unit-name" type="text" value={unitFormName} onChange={e => setUnitFormName(e.target.value)} placeholder="例: 営業第一グループ"
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
               </div>
               <div className="space-y-1">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">種別</label>
-                <select value={unitFormType} onChange={e => setUnitFormType(e.target.value as OrganizationUnit['type'])}
+                <label htmlFor="unit-type" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">種別</label>
+                <select id="unit-type" value={unitFormType} onChange={e => setUnitFormType(e.target.value as OrganizationUnit['type'])}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   <option value="division">Division（事業部）</option>
                   <option value="group">Group（部）</option>
@@ -1562,8 +1572,8 @@ export default function AdminSettings() {
                 </select>
               </div>
               <div className="space-y-1">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">親ユニット</label>
-                <select value={unitFormParentId} onChange={e => setUnitFormParentId(e.target.value)}
+                <label htmlFor="unit-parent" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">親ユニット</label>
+                <select id="unit-parent" value={unitFormParentId} onChange={e => setUnitFormParentId(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   <option value="">なし（ルートとして追加）</option>
                   {orgUnits.filter(u => u.status === 'active').map(u => <option key={u.id} value={u.id}>{u.name}</option>)}

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -413,6 +413,7 @@ export default function RequestInbox() {
             <Search className="absolute left-3 top-2.5 w-4 h-4 text-slate-300" />
             <input
               type="text"
+              aria-label="依頼を検索"
               placeholder="依頼を検索..."
               value={inboxSearchQuery}
               onChange={(e) => setInboxSearchQuery(e.target.value)}
@@ -552,6 +553,7 @@ export default function RequestInbox() {
               </div>
               <textarea
                 rows={4}
+                aria-label="差し戻し理由"
                 placeholder="差し戻し理由を入力してください（必須）..."
                 value={rejectComment}
                 onChange={(e) => setRejectComment(e.target.value)}
@@ -602,6 +604,7 @@ export default function RequestInbox() {
                 <Search className="absolute left-3 top-2.5 w-4 h-4 text-slate-300" />
                 <input
                   type="text"
+                  aria-label="承認者を検索"
                   placeholder="氏名で検索..."
                   value={approverSearchQuery}
                   onChange={(e) => setApproverSearchQuery(e.target.value)}
@@ -941,8 +944,9 @@ export default function RequestInbox() {
                   {user?.avatar ? <Image src={user.avatar} width={40} height={40} className="w-full h-full rounded-full object-cover" alt="avatar" /> : 'U'}
                 </div>
                 <div className="flex-1 space-y-3">
-                  <textarea 
+                  <textarea
                     rows={3}
+                    aria-label="コメントを入力"
                     placeholder="申請内容に関する質問や連絡事項を入力してください..."
                     className="w-full p-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm font-medium focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all resize-none"
                     value={commentText}

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -534,9 +534,10 @@ function RequestFormContent() {
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">大分類</label>
+                <label htmlFor="req-large-category" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">大分類</label>
                 <div className="relative group">
-                  <select 
+                  <select
+                    id="req-large-category"
                     className="w-full h-12 pl-4 pr-10 bg-slate-50 border border-slate-200 rounded-xl appearance-none focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all font-bold text-slate-900"
                     onChange={(e) => {
                       setLargeCategory(e.target.value);
@@ -551,9 +552,10 @@ function RequestFormContent() {
                 </div>
               </div>
               <div className="space-y-2">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">中分類</label>
+                <label htmlFor="req-medium-category" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">中分類</label>
                 <div className="relative group">
-                  <select 
+                  <select
+                    id="req-medium-category"
                     className="w-full h-12 pl-4 pr-10 bg-slate-50 border border-slate-200 rounded-xl appearance-none focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all font-bold text-slate-900 disabled:opacity-50"
                     disabled={!largeCategory}
                     onChange={(e) => {
@@ -620,8 +622,9 @@ function RequestFormContent() {
               </div>
 
               <div className="space-y-2" id="field-__title">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">タイトル <span className="text-rose-500">*</span></label>
+                <label htmlFor="req-title" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">タイトル <span className="text-rose-500">*</span></label>
                 <input
+                  id="req-title"
                   type="text"
                   placeholder="例：2026年度 資格取得祝金申請"
                   className={`w-full h-12 px-4 bg-white border rounded-xl focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all font-bold text-slate-900 ${fieldErrors['__title'] ? 'border-rose-400 ring-1 ring-rose-300' : 'border-slate-200'}`}
@@ -633,8 +636,9 @@ function RequestFormContent() {
                 {fieldErrors['__title'] && <p id="err-__title" className="text-xs text-rose-500 font-bold px-1">{fieldErrors['__title']}</p>}
               </div>
               <div className="space-y-2" id="field-__description">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">詳細説明 / 追記</label>
+                <label htmlFor="req-description" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">詳細説明 / 追記</label>
                 <textarea
+                  id="req-description"
                   rows={6}
                   placeholder="申請の背景、希望する対応内容などを記載してください。"
                   className={`w-full p-4 bg-white border rounded-xl focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all font-medium text-slate-900 resize-none ${fieldErrors['__description'] ? 'border-rose-400 ring-1 ring-rose-300' : 'border-slate-200'}`}
@@ -665,7 +669,10 @@ function RequestFormContent() {
                       };
                       return (
                         <div key={field.id} className="space-y-2" id={`field-${field.id}`}>
-                          <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">
+                          <label
+                            htmlFor={!['checkbox', 'file'].includes(field.type) ? `custom-field-${field.id}` : undefined}
+                            className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1"
+                          >
                             {field.label}
                             {field.required && <span className="text-rose-500 ml-1">*</span>}
                           </label>
@@ -673,6 +680,7 @@ function RequestFormContent() {
                           {field.type === 'select' ? (
                             <div className="relative">
                               <select
+                                id={`custom-field-${field.id}`}
                                 className={inputClass('w-full h-12 pl-4 pr-10 bg-slate-50 border rounded-xl appearance-none focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all font-bold text-slate-900')}
                                 value={customData[field.label] || ''}
                                 onChange={(e) => handleChange(e.target.value)}
@@ -686,6 +694,7 @@ function RequestFormContent() {
                             </div>
                           ) : field.type === 'textarea' ? (
                             <textarea
+                              id={`custom-field-${field.id}`}
                               rows={3}
                               className={inputClass('w-full px-4 py-3 bg-slate-50 border rounded-xl focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all text-sm text-slate-900 resize-none')}
                               placeholder={field.placeholder ?? `${field.label}を入力...`}
@@ -714,6 +723,7 @@ function RequestFormContent() {
                             </label>
                           ) : field.type === 'date' ? (
                             <input
+                              id={`custom-field-${field.id}`}
                               type="date"
                               className={inputClass('w-full h-12 px-4 bg-slate-50 border rounded-xl focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all font-bold text-slate-900')}
                               value={customData[field.label] || ''}
@@ -723,6 +733,7 @@ function RequestFormContent() {
                             />
                           ) : (
                             <input
+                              id={`custom-field-${field.id}`}
                               type={field.type === 'number' ? 'number' : 'text'}
                               className={inputClass('w-full h-12 px-4 bg-slate-50 border rounded-xl focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all font-bold text-slate-900')}
                               placeholder={field.placeholder ?? `${field.label}を入力...`}
@@ -1048,9 +1059,10 @@ function RequestFormContent() {
               </div>
               <div className="relative">
                 <Search className="absolute left-4 top-3.5 w-5 h-5 text-slate-300" />
-                <input 
-                  type="text" 
+                <input
+                  type="text"
                   autoFocus
+                  aria-label="ユーザーを検索"
                   placeholder="氏名や役職で検索..."
                   className="w-full h-12 pl-12 pr-4 bg-slate-50 border border-slate-200 rounded-xl focus:outline-none focus:border-slate-900 transition-all font-bold"
                   value={searchQuery}


### PR DESCRIPTION
## Summary

- `src/app/request/page.tsx`: 大分類/中分類 select、タイトル input、詳細説明 textarea に `htmlFor`/`id` を追加。動的カスタムフィールド（select/textarea/date/number/text）にも `id` を付与し対応する `label` に `htmlFor` を追加。検索モーダルの input に `aria-label` を追加。
- `src/app/inbox/page.tsx`: 依頼検索・差し戻し理由・承認者検索・コメント入力の 4 要素に `aria-label` を追加。
- `src/app/admin/page.tsx`: テナント名、代決モーダル（委任者・代理人・日付・理由）、変更モーダル（対象ユーザー・種別・日付・新組織・新上長）、ユーザー追加/編集モーダル（氏名・メール・役職・組織ユニット）、カテゴリーモーダル（カテゴリー名・親・SLA）、動的フォーム項目・承認フロー定義の各コントロール、組織ユニットモーダル（ユニット名・種別・親）に `htmlFor`/`id` または `aria-label` を付与。

Closes #33

## Test plan

- [ ] request ページでフォームフィールドを Tab キーで移動し、スクリーンリーダー等でラベルが読み上げられることを確認
- [ ] admin ページの各モーダル（代決・変更・ユーザー追加/編集・カテゴリー・ユニット）を開き、Tab 移動時にフィールド名が読み上げられることを確認
- [ ] inbox ページの検索・差し戻しモーダル・コメント欄で `aria-label` が付与されていることをブラウザの開発者ツールで確認
- [ ] `npm run typecheck` および `npm run lint` がエラーなしで通過すること