### PR TITLE
feat(a11y): WCAG 2.1 AA カラーコントラスト確認・修正

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -379,7 +379,7 @@ export default function AdminSettings() {
               "shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-bold transition-all border",
               activeTab === tab.id
                 ? "bg-slate-900 text-white border-slate-900"
-                : "text-slate-400 border-slate-200 hover:border-slate-400"
+                : "text-slate-500 border-slate-200 hover:border-slate-400"
             )}
           >
             <tab.icon className="w-3.5 h-3.5" />
@@ -405,7 +405,7 @@ export default function AdminSettings() {
                 "w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm font-bold transition-all",
                 activeTab === tab.id
                   ? "bg-slate-900 text-white shadow-xl translate-x-1"
-                  : "text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+                  : "text-slate-500 hover:text-slate-600 hover:bg-slate-100"
               )}
             >
               <tab.icon className="w-4 h-4" />
@@ -429,9 +429,9 @@ export default function AdminSettings() {
                   { label: '平均処理日数', value: `${adminStats.avgDays}日`, sub: 'Avg. Lead Time', color: 'text-amber-600' },
                 ].map(stat => (
                   <div key={stat.label} className="bg-white border border-slate-200 rounded-2xl notion-shadow p-3 space-y-1">
-                    <div className="text-[10px] font-black text-slate-400 uppercase tracking-widest">{stat.label}</div>
+                    <div className="text-[10px] font-black text-slate-500 uppercase tracking-widest">{stat.label}</div>
                     <div className={`text-2xl font-black ${stat.color}`}>{stat.value}</div>
-                    <div className="text-[9px] font-bold text-slate-300 uppercase tracking-widest">{stat.sub}</div>
+                    <div className="text-[9px] font-bold text-slate-500 uppercase tracking-widest">{stat.sub}</div>
                   </div>
                 ))}
               </div>
@@ -440,7 +440,7 @@ export default function AdminSettings() {
                 <div className="flex items-center justify-between">
                   <div>
                     <h2 className="text-xl font-bold text-[#191714]">システム基本情報</h2>
-                    <p className="text-xs font-bold text-slate-400 uppercase tracking-widest mt-1">General System Settings</p>
+                    <p className="text-xs font-bold text-slate-500 uppercase tracking-widest mt-1">General System Settings</p>
                   </div>
                   <div className="flex items-center gap-2">
                     <button
@@ -457,7 +457,7 @@ export default function AdminSettings() {
                         mockProvider.clearStorage();
                         window.location.reload();
                       }}
-                      className="flex items-center gap-2 px-4 py-2 border border-rose-200 text-rose-500 rounded-xl text-xs font-bold hover:bg-rose-50 transition-all"
+                      className="flex items-center gap-2 px-4 py-2 border border-rose-200 text-rose-600 rounded-xl text-xs font-bold hover:bg-rose-50 transition-all"
                     >
                       <RefreshCw className="w-4 h-4" />
                       データをリセット
@@ -478,7 +478,7 @@ export default function AdminSettings() {
                 )}
                 <div className="grid grid-cols-2 gap-8 pt-4">
                   <div className="space-y-2">
-                    <label htmlFor="admin-tenant-name" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">テナント名</label>
+                    <label htmlFor="admin-tenant-name" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">テナント名</label>
                     <input
                       id="admin-tenant-name"
                       type="text"
@@ -488,7 +488,7 @@ export default function AdminSettings() {
                     />
                   </div>
                   <div className="space-y-2">
-                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">データソース</label>
+                    <label className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">データソース</label>
                     <div className="w-full h-10 px-4 bg-slate-100 border rounded-xl flex items-center justify-between">
                       <span className="text-sm font-bold text-slate-500">SharePoint Lists (Mocked)</span>
                       <Shield className="w-4 h-4 text-emerald-500" />
@@ -507,7 +507,7 @@ export default function AdminSettings() {
                       </div>
                       <div>
                         <h3 className="text-sm font-black text-rose-800">SLA 超過アラート</h3>
-                        <p className="text-[10px] font-bold text-rose-400 uppercase tracking-widest">
+                        <p className="text-[10px] font-bold text-rose-700 uppercase tracking-widest">
                           {tasks.filter(t => t.status !== 'completed' && new Date(t.dueDate) < new Date()).length}件のタスクが期限を超過しています
                         </p>
                       </div>
@@ -524,7 +524,7 @@ export default function AdminSettings() {
                           <div key={t.id} className="flex items-center gap-4 px-5 py-3 hover:bg-rose-50/30 transition-colors">
                             <div className="flex-1 min-w-0">
                               <div className="text-sm font-bold text-[#191714] truncate">{t.title}</div>
-                              <div className="text-[10px] font-bold text-slate-400 mt-0.5">{t.category} ／ 担当: {t.currentApproverName ?? '未設定'}</div>
+                              <div className="text-[10px] font-bold text-slate-500 mt-0.5">{t.category} ／ 担当: {t.currentApproverName ?? '未設定'}</div>
                             </div>
                             <span className="shrink-0 text-[10px] font-black text-rose-600 bg-rose-50 border border-rose-200 px-2.5 py-1 rounded-full">
                               +{overdueDays}日超過
@@ -555,7 +555,7 @@ export default function AdminSettings() {
                 <div className="p-6 border-b flex items-center justify-between">
                   <div>
                     <h2 className="text-xl font-bold text-[#191714]">組織・メンバー管理</h2>
-                    <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-1">Total {users.length} Members Sampled</p>
+                    <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mt-1">Total {users.length} Members Sampled</p>
                   </div>
                   <div className="flex gap-2">
                     <button 
@@ -586,10 +586,10 @@ export default function AdminSettings() {
                   <table className="w-full text-left">
                     <thead>
                       <tr className="bg-slate-50/50 border-b">
-                        <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">氏名 / メールアドレス</th>
-                        <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">役職</th>
-                        <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">所属ユニット</th>
-                        <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">ステータス</th>
+                        <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">氏名 / メールアドレス</th>
+                        <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">役職</th>
+                        <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">所属ユニット</th>
+                        <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">ステータス</th>
                         <th className="w-10"></th>
                       </tr>
                     </thead>
@@ -598,19 +598,19 @@ export default function AdminSettings() {
                         <tr key={u.id} className="hover:bg-slate-50/50 transition-colors group">
                           <td className="px-6 py-4">
                             <div className="flex items-center gap-3">
-                              <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center text-[10px] font-bold text-slate-400">
+                              <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center text-[10px] font-bold text-slate-500">
                                 {u.name.charAt(0)}
                               </div>
                               <div>
                                 <div className="text-sm font-bold text-[#191714]">{u.name}</div>
-                                <div className="text-[10px] font-medium text-slate-400">{u.email}</div>
+                                <div className="text-[10px] font-medium text-slate-500">{u.email}</div>
                               </div>
                             </div>
                           </td>
                           <td className="px-6 py-4">
                             <span className="text-[10px] font-black uppercase tracking-tight bg-slate-100 px-2 py-0.5 rounded-full text-slate-600">{u.position}</span>
                           </td>
-                          <td className="px-6 py-4 text-xs font-bold text-slate-400">
+                          <td className="px-6 py-4 text-xs font-bold text-slate-500">
                             {u.orgUnitId.split('_').pop()}
                           </td>
                           <td className="px-6 py-4">
@@ -621,13 +621,13 @@ export default function AdminSettings() {
                               </span>
                             )}
                             {u.status === 'inactive' && (
-                              <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-slate-50 text-slate-400 text-[10px] font-bold border border-slate-200">
+                              <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-slate-50 text-slate-500 text-[10px] font-bold border border-slate-200">
                                 <div className="w-1 h-1 rounded-full bg-slate-300" />
                                 無効
                               </span>
                             )}
                             {u.status === 'on_leave' && (
-                              <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-amber-50 text-amber-600 text-[10px] font-bold border border-amber-100">
+                              <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 text-[10px] font-bold border border-amber-100">
                                 <div className="w-1 h-1 rounded-full bg-amber-500" />
                                 休職中
                               </span>
@@ -638,7 +638,7 @@ export default function AdminSettings() {
                               onClick={() => setUserMenuTargetId(prev => prev === u.id ? null : u.id)}
                               className="p-1.5 hover:bg-slate-200 rounded-lg transition-colors opacity-0 group-hover:opacity-100"
                             >
-                              <MoreHorizontal className="w-4 h-4 text-slate-400" />
+                              <MoreHorizontal className="w-4 h-4 text-slate-500" />
                             </button>
                             {userMenuTargetId === u.id && (
                               <>
@@ -648,20 +648,20 @@ export default function AdminSettings() {
                                     onClick={() => { setEditingUser(u); setEditUserName(u.name); setEditUserEmail(u.email); setEditUserPosition(u.position); setEditUserOrgUnit(u.orgUnitId); setShowEditUserModal(true); setUserMenuTargetId(null); }}
                                     className="w-full text-left px-3 py-2 text-xs font-bold text-slate-600 hover:bg-slate-50 transition-colors flex items-center gap-2"
                                   >
-                                    <Settings className="w-3.5 h-3.5 text-slate-400" />
+                                    <Settings className="w-3.5 h-3.5 text-slate-500" />
                                     プロフィール編集
                                   </button>
                                   <button
                                     onClick={() => { setSelectedUser(u.id); setIsChangeModalOpen(true); setUserMenuTargetId(null); }}
                                     className="w-full text-left px-3 py-2 text-xs font-bold text-slate-600 hover:bg-slate-50 transition-colors flex items-center gap-2"
                                   >
-                                    <RefreshCw className="w-3.5 h-3.5 text-slate-400" />
+                                    <RefreshCw className="w-3.5 h-3.5 text-slate-500" />
                                     人事・組織変更
                                   </button>
                                   {u.status === 'active' && (
                                     <button
                                       onClick={() => { setDeactivatingUser(u); setUserMenuTargetId(null); }}
-                                      className="w-full text-left px-3 py-2 text-xs font-bold text-rose-500 hover:bg-rose-50 transition-colors flex items-center gap-2 border-t border-slate-100"
+                                      className="w-full text-left px-3 py-2 text-xs font-bold text-rose-600 hover:bg-rose-50 transition-colors flex items-center gap-2 border-t border-slate-100"
                                     >
                                       <Trash2 className="w-3.5 h-3.5" />
                                       無効化
@@ -683,7 +683,7 @@ export default function AdminSettings() {
                 <div className="p-6 border-b flex items-center justify-between">
                   <div>
                     <h2 className="text-xl font-bold text-[#191714]">組織ユニット管理</h2>
-                    <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-1">Departments & Teams</p>
+                    <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mt-1">Departments & Teams</p>
                   </div>
                   <button
                     onClick={() => { setShowAddUnitModal(true); setUnitFormName(''); setUnitFormType('team'); setUnitFormParentId(''); }}
@@ -697,10 +697,10 @@ export default function AdminSettings() {
                   <table className="w-full text-left">
                     <thead>
                       <tr className="bg-slate-50/50 border-b">
-                        <th className="px-6 py-3 text-[10px] font-bold text-slate-400 uppercase tracking-widest">ユニット名</th>
-                        <th className="px-6 py-3 text-[10px] font-bold text-slate-400 uppercase tracking-widest">種別</th>
-                        <th className="px-6 py-3 text-[10px] font-bold text-slate-400 uppercase tracking-widest">親ユニット</th>
-                        <th className="px-6 py-3 text-[10px] font-bold text-slate-400 uppercase tracking-widest">ステータス</th>
+                        <th className="px-6 py-3 text-[10px] font-bold text-slate-500 uppercase tracking-widest">ユニット名</th>
+                        <th className="px-6 py-3 text-[10px] font-bold text-slate-500 uppercase tracking-widest">種別</th>
+                        <th className="px-6 py-3 text-[10px] font-bold text-slate-500 uppercase tracking-widest">親ユニット</th>
+                        <th className="px-6 py-3 text-[10px] font-bold text-slate-500 uppercase tracking-widest">ステータス</th>
                         <th className="w-24"></th>
                       </tr>
                     </thead>
@@ -713,18 +713,18 @@ export default function AdminSettings() {
                             <td className="px-6 py-3">
                               <span className="text-[10px] font-black uppercase tracking-tight bg-slate-100 px-2 py-0.5 rounded-full text-slate-600">{unit.type}</span>
                             </td>
-                            <td className="px-6 py-3 text-xs font-bold text-slate-400">{parent?.name || '—'}</td>
+                            <td className="px-6 py-3 text-xs font-bold text-slate-500">{parent?.name || '—'}</td>
                             <td className="px-6 py-3">
                               {unit.status === 'active'
                                 ? <span className="text-[10px] font-bold text-emerald-600 bg-emerald-50 border border-emerald-100 px-2 py-0.5 rounded-full">有効</span>
-                                : <span className="text-[10px] font-bold text-slate-400 bg-slate-50 border border-slate-200 px-2 py-0.5 rounded-full">アーカイブ</span>
+                                : <span className="text-[10px] font-bold text-slate-500 bg-slate-50 border border-slate-200 px-2 py-0.5 rounded-full">アーカイブ</span>
                               }
                             </td>
                             <td className="pr-4 text-right">
                               <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-all">
                                 <button
                                   onClick={() => { setEditingUnit(unit); setUnitFormName(unit.name); setUnitFormType(unit.type); setUnitFormParentId(unit.parentId || ''); }}
-                                  className="p-1.5 hover:bg-slate-100 rounded-lg text-slate-400 transition-all"
+                                  className="p-1.5 hover:bg-slate-100 rounded-lg text-slate-500 transition-all"
                                 >
                                   <Settings className="w-3.5 h-3.5" />
                                 </button>
@@ -754,7 +754,7 @@ export default function AdminSettings() {
                 <div className="p-6 border-b flex items-center justify-between">
                   <div>
                     <h2 className="text-xl font-bold text-[#191714]">申請カテゴリーマスタ</h2>
-                    <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-1">Configure SLA and Approval Templates</p>
+                    <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mt-1">Configure SLA and Approval Templates</p>
                   </div>
                   <button
                     onClick={() => { setShowAddCatModal(true); setCatFormName(''); setCatFormParentId(''); setCatFormSla(5); setCatFormAmountRules([]); setCatFormFields([]); setCatFormWorkflow([]); setCatFormTab('basic'); }}
@@ -770,7 +770,7 @@ export default function AdminSettings() {
                     return (
                       <div key={cat.id} className="p-4 bg-slate-50 border rounded-2xl flex items-center justify-between hover:border-slate-900 transition-all cursor-pointer group">
                         <div>
-                          <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{parent?.name || '基本カテゴリ'}</div>
+                          <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">{parent?.name || '基本カテゴリ'}</div>
                           <div className="text-sm font-bold text-[#191714]">{cat.name}</div>
                           <div className="mt-2 flex items-center gap-2">
                             <Clock className="w-3 h-3 text-emerald-500" />
@@ -780,7 +780,7 @@ export default function AdminSettings() {
                         <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-all">
                           <button
                             onClick={(e) => { e.stopPropagation(); setEditingCategory(cat); setCatFormName(cat.name); setCatFormParentId(cat.parentId || ''); setCatFormSla(cat.slaDays ?? 5); setCatFormAmountRules(cat.amountRules ?? []); setCatFormFields(cat.customFields ?? []); setCatFormWorkflow(cat.workflowTemplate ?? []); setCatFormTab('basic'); }}
-                            className="p-2 hover:bg-white rounded-lg text-slate-400 border border-transparent hover:border-slate-200 transition-all"
+                            className="p-2 hover:bg-white rounded-lg text-slate-500 border border-transparent hover:border-slate-200 transition-all"
                           ><Settings className="w-3.5 h-3.5" /></button>
                           <button
                             onClick={(e) => { e.stopPropagation(); setDeletingCategory(cat); }}
@@ -801,7 +801,7 @@ export default function AdminSettings() {
                 <div className="flex items-center justify-between">
                   <div>
                     <h2 className="text-base font-black text-[#191714]">代決設定</h2>
-                    <p className="text-xs text-slate-400 font-medium mt-0.5">不在時などに代理で承認できるユーザーを設定します。</p>
+                    <p className="text-xs text-slate-500 font-medium mt-0.5">不在時などに代理で承認できるユーザーを設定します。</p>
                   </div>
                   <button
                     onClick={() => setShowAddDelegationModal(true)}
@@ -813,7 +813,7 @@ export default function AdminSettings() {
                 </div>
                 <div className="space-y-2">
                   {delegations.length === 0 && (
-                    <p className="text-sm text-slate-400 text-center py-8">代決設定はありません</p>
+                    <p className="text-sm text-slate-500 text-center py-8">代決設定はありません</p>
                   )}
                   {delegations.map(d => {
                     const delegator = users.find(u => u.id === d.delegatorId);
@@ -823,13 +823,13 @@ export default function AdminSettings() {
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2 flex-wrap">
                             <span className="text-sm font-bold text-slate-800">{delegator?.name ?? d.delegatorId}</span>
-                            <span className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">→ 代理:</span>
+                            <span className="text-[10px] text-slate-500 font-bold uppercase tracking-widest">→ 代理:</span>
                             <span className="text-sm font-bold text-violet-700">{delegate?.name ?? d.delegateId}</span>
-                            {!d.isActive && <span className="px-2 py-0.5 bg-slate-100 text-slate-400 text-[9px] font-black rounded-full uppercase">無効</span>}
+                            {!d.isActive && <span className="px-2 py-0.5 bg-slate-100 text-slate-500 text-[9px] font-black rounded-full uppercase">無効</span>}
                           </div>
                           <div className="flex items-center gap-3 mt-1">
-                            <span className="text-[10px] text-slate-400 font-medium">{d.startDate} 〜 {d.endDate ?? '終了日なし'}</span>
-                            {d.reason && <span className="text-[10px] text-slate-400 font-medium truncate max-w-xs">{d.reason}</span>}
+                            <span className="text-[10px] text-slate-500 font-medium">{d.startDate} 〜 {d.endDate ?? '終了日なし'}</span>
+                            {d.reason && <span className="text-[10px] text-slate-500 font-medium truncate max-w-xs">{d.reason}</span>}
                           </div>
                         </div>
                         {d.isActive && (
@@ -860,12 +860,12 @@ export default function AdminSettings() {
                     <div className="p-6 border-b flex items-center justify-between">
                       <h3 id="delegation-modal-title" className="text-lg font-bold text-[#191714]">代決設定を追加</h3>
                       <button type="button" onClick={() => setShowAddDelegationModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
-                        <X className="w-5 h-5 text-slate-400" />
+                        <X className="w-5 h-5 text-slate-500" />
                       </button>
                     </div>
                     <div className="p-6 space-y-4">
                       <div className="space-y-1">
-                        <label htmlFor="del-delegator" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">権限を委任する人（不在者）<span className="text-rose-500">*</span></label>
+                        <label htmlFor="del-delegator" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">権限を委任する人（不在者）<span className="text-rose-600">*</span></label>
                         <select
                           id="del-delegator"
                           className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all"
@@ -879,7 +879,7 @@ export default function AdminSettings() {
                         </select>
                       </div>
                       <div className="space-y-1">
-                        <label htmlFor="del-delegate" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">代理承認者<span className="text-rose-500">*</span></label>
+                        <label htmlFor="del-delegate" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">代理承認者<span className="text-rose-600">*</span></label>
                         <select
                           id="del-delegate"
                           className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all"
@@ -894,16 +894,16 @@ export default function AdminSettings() {
                       </div>
                       <div className="grid grid-cols-2 gap-3">
                         <div className="space-y-1">
-                          <label htmlFor="del-start-date" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">開始日<span className="text-rose-500">*</span></label>
+                          <label htmlFor="del-start-date" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">開始日<span className="text-rose-600">*</span></label>
                           <input id="del-start-date" type="date" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delStartDate} onChange={e => setDelStartDate(e.target.value)} />
                         </div>
                         <div className="space-y-1">
-                          <label htmlFor="del-end-date" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">終了日（任意）</label>
+                          <label htmlFor="del-end-date" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">終了日（任意）</label>
                           <input id="del-end-date" type="date" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delEndDate} onChange={e => setDelEndDate(e.target.value)} />
                         </div>
                       </div>
                       <div className="space-y-1">
-                        <label htmlFor="del-reason" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">理由・備考</label>
+                        <label htmlFor="del-reason" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">理由・備考</label>
                         <input id="del-reason" type="text" placeholder="例：出張、育休など" className="w-full h-10 px-3 bg-slate-50 border border-slate-200 rounded-xl text-sm font-bold focus:outline-none focus:border-slate-900 transition-all" value={delReason} onChange={e => setDelReason(e.target.value)} />
                       </div>
                       <div className="flex gap-3 pt-2">
@@ -922,7 +922,7 @@ export default function AdminSettings() {
                <section className="bg-white rounded-3xl border border-slate-200 notion-shadow p-8 flex flex-col items-center justify-center text-center py-20">
                  <Shield className="w-12 h-12 text-slate-200 mb-4" />
                  <h2 className="text-xl font-bold text-[#191714]">セキュリティ・権限設定</h2>
-                 <p className="text-sm text-slate-400 max-w-sm">システム権限ロールやIP制限の設定は、現在準備中です。プロトタイプ版ではデフォルトのRoleBasedPolicyが適用されています。</p>
+                 <p className="text-sm text-slate-500 max-w-sm">システム権限ロールやIP制限の設定は、現在準備中です。プロトタイプ版ではデフォルトのRoleBasedPolicyが適用されています。</p>
                </section>
             </div>
           )}
@@ -934,12 +934,12 @@ export default function AdminSettings() {
                   <div className="flex items-center justify-between">
                     <div>
                       <h2 className="text-xl font-bold text-[#191714]">全社監査ログ</h2>
-                      <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-1">System-wide Activity History</p>
+                      <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mt-1">System-wide Activity History</p>
                     </div>
                   </div>
                   <div className="flex flex-wrap gap-3 items-center">
                     <div className="relative flex-1 min-w-48">
-                      <Search className="w-4 h-4 text-slate-400 absolute left-3 top-1/2 -translate-y-1/2" />
+                      <Search className="w-4 h-4 text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />
                       <input
                         type="text"
                         aria-label="監査ログを検索"
@@ -950,7 +950,7 @@ export default function AdminSettings() {
                       />
                     </div>
                     <div className="flex items-center gap-2">
-                      <CalendarDays className="w-4 h-4 text-slate-400" />
+                      <CalendarDays className="w-4 h-4 text-slate-500" />
                       <input
                         type="date"
                         aria-label="開始日"
@@ -969,7 +969,7 @@ export default function AdminSettings() {
                       {(logStartDate || logEndDate) && (
                         <button
                           onClick={() => { setLogStartDate(''); setLogEndDate(''); }}
-                          className="text-[10px] font-bold text-slate-400 hover:text-slate-700 transition-colors uppercase tracking-widest"
+                          className="text-[10px] font-bold text-slate-500 hover:text-slate-700 transition-colors uppercase tracking-widest"
                         >
                           クリア
                         </button>
@@ -981,10 +981,10 @@ export default function AdminSettings() {
                   <table className="w-full text-left">
                     <thead>
                       <tr className="bg-slate-50/50 border-b">
-                        <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">日時</th>
-                        <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">実行者</th>
-                        <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">アクション</th>
-                        <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">詳細</th>
+                        <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">日時</th>
+                        <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">実行者</th>
+                        <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">アクション</th>
+                        <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">詳細</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-100">
@@ -997,7 +997,7 @@ export default function AdminSettings() {
                           </td>
                           <td className="px-6 py-4">
                             <span className="text-sm font-bold text-[#191714]">{log.userName}</span>
-                            {log.comment && <p className="text-[10px] text-slate-400 mt-1 line-clamp-1">{log.comment}</p>}
+                            {log.comment && <p className="text-[10px] text-slate-500 mt-1 line-clamp-1">{log.comment}</p>}
                           </td>
                           <td className="px-6 py-4">
                             <span className={cn(
@@ -1021,7 +1021,7 @@ export default function AdminSettings() {
                       ))}
                       {filteredLogs.length === 0 && (
                         <tr>
-                          <td colSpan={4} className="px-6 py-12 text-center text-slate-400 text-sm font-medium">
+                          <td colSpan={4} className="px-6 py-12 text-center text-slate-500 text-sm font-medium">
                             該当するログデータがありません
                           </td>
                         </tr>
@@ -1048,7 +1048,7 @@ export default function AdminSettings() {
             <div className="p-6 border-b flex items-center justify-between bg-slate-50/50">
               <div>
                 <h3 id="change-modal-title" className="text-xl font-bold text-[#191714]">人事・組織変更の登録</h3>
-                <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-1">Schedule Personnel Event</p>
+                <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mt-1">Schedule Personnel Event</p>
               </div>
               <button type="button" onClick={() => setIsChangeModalOpen(false)} className="p-2 hover:bg-slate-200 rounded-xl transition-colors" aria-label="閉じる">
                 <ChevronRight className="w-5 h-5 rotate-90" />
@@ -1057,7 +1057,7 @@ export default function AdminSettings() {
             
             <div className="p-8 space-y-6 max-h-[70vh] overflow-y-auto">
               <div className="space-y-2">
-                <label htmlFor="change-target-user" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">対象ユーザー</label>
+                <label htmlFor="change-target-user" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">対象ユーザー</label>
                 <select
                   id="change-target-user"
                   value={selectedUser}
@@ -1073,7 +1073,7 @@ export default function AdminSettings() {
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <label htmlFor="change-type-select" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">変更種別</label>
+                  <label htmlFor="change-type-select" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">変更種別</label>
                   <select
                     id="change-type-select"
                     value={changeType}
@@ -1087,10 +1087,10 @@ export default function AdminSettings() {
                   </select>
                 </div>
                 <div className="space-y-2">
-                  <label htmlFor="change-scheduled-date" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">適用予定日</label>
+                  <label htmlFor="change-scheduled-date" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">適用予定日</label>
                   <div className="relative">
                     <input id="change-scheduled-date" type="date" className="w-full h-12 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all pl-10" />
-                    <CalendarDays className="w-4 h-4 absolute left-4 top-4 text-slate-400" />
+                    <CalendarDays className="w-4 h-4 absolute left-4 top-4 text-slate-500" />
                   </div>
                 </div>
               </div>
@@ -1098,7 +1098,7 @@ export default function AdminSettings() {
               {(changeType === 'transfer' || changeType === 'promotion') && (
                 <div className="space-y-4 pt-4 border-t border-dashed">
                   <div className="space-y-2">
-                    <label htmlFor="change-new-org" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">新所属組織</label>
+                    <label htmlFor="change-new-org" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">新所属組織</label>
                     <select
                       id="change-new-org"
                       value={newOrgUnit}
@@ -1112,7 +1112,7 @@ export default function AdminSettings() {
                     </select>
                   </div>
                   <div className="space-y-2">
-                    <label htmlFor="change-new-manager" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">新直属上長</label>
+                    <label htmlFor="change-new-manager" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">新直属上長</label>
                     <select
                       id="change-new-manager"
                       value={newManager}
@@ -1162,7 +1162,7 @@ export default function AdminSettings() {
           <div className="bg-white w-full max-w-md rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300">
             <div className="p-6 border-b flex items-center justify-between">
               <h3 className="text-lg font-bold text-[#191714]">インポート結果</h3>
-              <button onClick={() => setImportResult(null)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors"><X className="w-5 h-5 text-slate-400" /></button>
+              <button onClick={() => setImportResult(null)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors"><X className="w-5 h-5 text-slate-500" /></button>
             </div>
             <div className="p-6 space-y-3">
               <p className="text-sm font-bold text-emerald-700 bg-emerald-50 border border-emerald-200 px-4 py-2 rounded-xl">{importResult.count} 件を更新しました</p>
@@ -1190,7 +1190,7 @@ export default function AdminSettings() {
           >
             <div className="p-6 border-b flex items-center justify-between">
               <h3 id="add-user-modal-title" className="text-lg font-bold text-[#191714]">メンバー新規追加</h3>
-              <button type="button" onClick={() => setShowAddUserModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-400" /></button>
+              <button type="button" onClick={() => setShowAddUserModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-500" /></button>
             </div>
             <div className="p-6 space-y-4">
               {[
@@ -1198,20 +1198,20 @@ export default function AdminSettings() {
                 { id: 'new-user-email', label: 'メールアドレス', value: newUserEmail, setter: setNewUserEmail, placeholder: 'example@company.co.jp' },
               ].map(({ id, label, value, setter, placeholder }) => (
                 <div key={label} className="space-y-1">
-                  <label htmlFor={id} className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">{label}</label>
+                  <label htmlFor={id} className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">{label}</label>
                   <input id={id} type="text" value={value} onChange={e => setter(e.target.value)} placeholder={placeholder}
                     className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
                 </div>
               ))}
               <div className="space-y-1">
-                <label htmlFor="new-user-position" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">役職</label>
+                <label htmlFor="new-user-position" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">役職</label>
                 <select id="new-user-position" value={newUserPosition} onChange={e => setNewUserPosition(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   {['President', 'Division Manager', 'General Manager', 'Team Leader', 'Member'].map(p => <option key={p} value={p}>{p}</option>)}
                 </select>
               </div>
               <div className="space-y-1">
-                <label htmlFor="new-user-org-unit" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">組織ユニット</label>
+                <label htmlFor="new-user-org-unit" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">組織ユニット</label>
                 <select id="new-user-org-unit" value={newUserOrgUnit} onChange={e => setNewUserOrgUnit(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   <option value="">選択してください</option>
@@ -1240,7 +1240,7 @@ export default function AdminSettings() {
           >
             <div className="p-6 border-b flex items-center justify-between shrink-0">
               <h3 id="cat-modal-title" className="text-lg font-bold text-[#191714]">{editingCategory ? 'カテゴリーを編集' : 'カテゴリーを追加'}</h3>
-              <button type="button" onClick={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-400" /></button>
+              <button type="button" onClick={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-500" /></button>
             </div>
 
             {/* タブ */}
@@ -1249,7 +1249,7 @@ export default function AdminSettings() {
                 <button
                   key={tab}
                   onClick={() => setCatFormTab(tab)}
-                  className={cn('flex-1 py-3 text-xs font-bold transition-colors', catFormTab === tab ? 'border-b-2 border-slate-900 text-slate-900' : 'text-slate-400 hover:text-slate-600')}
+                  className={cn('flex-1 py-3 text-xs font-bold transition-colors', catFormTab === tab ? 'border-b-2 border-slate-900 text-slate-900' : 'text-slate-500 hover:text-slate-600')}
                 >
                   {label}
                   {tab === 'fields' && catFormFields.length > 0 && <span className="ml-1 text-blue-500">({catFormFields.length})</span>}
@@ -1263,12 +1263,12 @@ export default function AdminSettings() {
               {catFormTab === 'basic' && (
                 <div className="space-y-4">
                   <div className="space-y-1">
-                    <label htmlFor="cat-name" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">カテゴリー名</label>
+                    <label htmlFor="cat-name" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">カテゴリー名</label>
                     <input id="cat-name" type="text" value={catFormName} onChange={e => setCatFormName(e.target.value)} placeholder="例: 資格取得祝金申請"
                       className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
                   </div>
                   <div className="space-y-1">
-                    <label htmlFor="cat-parent" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">大分類（親カテゴリー）</label>
+                    <label htmlFor="cat-parent" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">大分類（親カテゴリー）</label>
                     <select id="cat-parent" value={catFormParentId} onChange={e => setCatFormParentId(e.target.value)}
                       className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                       <option value="">なし（大分類として追加）</option>
@@ -1276,13 +1276,13 @@ export default function AdminSettings() {
                     </select>
                   </div>
                   <div className="space-y-1">
-                    <label htmlFor="cat-sla" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">目標SLA（営業日）</label>
+                    <label htmlFor="cat-sla" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">目標SLA（営業日）</label>
                     <input id="cat-sla" type="number" min={1} max={90} value={catFormSla} onChange={e => setCatFormSla(Number(e.target.value))}
                       className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
                   </div>
                   <div className="space-y-2 pt-2 border-t border-dashed border-slate-100">
                     <div className="flex items-center justify-between">
-                      <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">金額閾値ルール（任意）</label>
+                      <label className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">金額閾値ルール（任意）</label>
                       <button type="button" onClick={() => setCatFormAmountRules(prev => [...prev, { fieldLabel: '', minAmount: 0, requiredPosition: 'Division Manager' }])}
                         className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors">+ ルールを追加</button>
                     </div>
@@ -1292,13 +1292,13 @@ export default function AdminSettings() {
                           onChange={e => setCatFormAmountRules(prev => prev.map((r, i) => i === idx ? { ...r, fieldLabel: e.target.value } : r))}
                           className="h-9 px-3 bg-slate-50 border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
                         <div className="flex gap-1.5 items-center">
-                          <span className="text-xs text-slate-400 font-bold shrink-0">¥</span>
+                          <span className="text-xs text-slate-500 font-bold shrink-0">¥</span>
                           <input type="number" placeholder="閾値（例: 100000）" value={rule.minAmount || ''}
                             onChange={e => setCatFormAmountRules(prev => prev.map((r, i) => i === idx ? { ...r, minAmount: Number(e.target.value) } : r))}
                             className="flex-1 h-9 px-3 bg-slate-50 border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
                         </div>
                         <button type="button" onClick={() => setCatFormAmountRules(prev => prev.filter((_, i) => i !== idx))}
-                          className="h-9 w-9 flex items-center justify-center text-slate-300 hover:text-rose-500 hover:bg-rose-50 rounded-xl transition-all">
+                          className="h-9 w-9 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all">
                           <Trash2 className="w-3.5 h-3.5" />
                         </button>
                         <div className="col-span-2">
@@ -1312,7 +1312,7 @@ export default function AdminSettings() {
                         </div>
                       </div>
                     ))}
-                    {catFormAmountRules.length === 0 && <p className="text-[10px] text-slate-300 font-medium px-1">ルールなし（すべての金額で同一フローを適用）</p>}
+                    {catFormAmountRules.length === 0 && <p className="text-[10px] text-slate-500 font-medium px-1">ルールなし（すべての金額で同一フローを適用）</p>}
                   </div>
                 </div>
               )}
@@ -1327,7 +1327,7 @@ export default function AdminSettings() {
                       className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors whitespace-nowrap">+ 項目を追加</button>
                   </div>
                   {catFormFields.length === 0 && (
-                    <div className="py-8 text-center text-slate-300 text-xs">項目がありません。「+ 項目を追加」から追加してください。</div>
+                    <div className="py-8 text-center text-slate-500 text-xs">項目がありません。「+ 項目を追加」から追加してください。</div>
                   )}
                   {catFormFields.map((field, idx) => (
                     <div key={field.id} className="p-3 bg-slate-50 border rounded-2xl space-y-2">
@@ -1352,7 +1352,7 @@ export default function AdminSettings() {
                           必須
                         </label>
                         <button type="button" onClick={() => setCatFormFields(prev => prev.filter((_, i) => i !== idx))}
-                          className="h-8 w-8 flex items-center justify-center text-slate-300 hover:text-rose-500 hover:bg-rose-50 rounded-xl transition-all shrink-0">
+                          className="h-8 w-8 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all shrink-0">
                           <Trash2 className="w-3.5 h-3.5" />
                         </button>
                       </div>
@@ -1361,7 +1361,7 @@ export default function AdminSettings() {
                         className="w-full h-7 px-3 bg-white border rounded-xl text-[11px] text-slate-500 focus:outline-none focus:border-slate-400 transition-all" />
                       {field.type === 'select' && (
                         <div className="space-y-1">
-                          <p className="text-[10px] text-slate-400 font-bold">選択肢（改行区切り）</p>
+                          <p className="text-[10px] text-slate-500 font-bold">選択肢（改行区切り）</p>
                           <textarea rows={3} aria-label="選択肢（改行区切り）" value={(field.options ?? []).join('\n')}
                             onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, options: e.target.value.split('\n').filter(Boolean) } : f))}
                             className="w-full px-3 py-2 bg-white border rounded-xl text-xs focus:outline-none focus:border-slate-400 transition-all resize-none" />
@@ -1382,17 +1382,17 @@ export default function AdminSettings() {
                       className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors whitespace-nowrap">+ ステップを追加</button>
                   </div>
                   {catFormWorkflow.length === 0 && (
-                    <div className="py-8 text-center text-slate-300 text-xs">ステップがありません。「+ ステップを追加」から追加してください。<br/>テンプレートなしの場合は申請者が手動で承認者を選択します。</div>
+                    <div className="py-8 text-center text-slate-500 text-xs">ステップがありません。「+ ステップを追加」から追加してください。<br/>テンプレートなしの場合は申請者が手動で承認者を選択します。</div>
                   )}
                   {catFormWorkflow.map((step, idx) => (
                     <div key={step.id} className="p-3 bg-slate-50 border rounded-2xl space-y-2">
                       <div className="flex gap-2 items-center">
-                        <span className="text-[10px] font-black text-slate-400 w-5 shrink-0">{idx + 1}</span>
+                        <span className="text-[10px] font-black text-slate-500 w-5 shrink-0">{idx + 1}</span>
                         <input type="text" aria-label="ステップ名" placeholder="ステップ名（例: 上長承認）" value={step.label}
                           onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, label: e.target.value } : s))}
                           className="flex-1 h-8 px-3 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
                         <button type="button" onClick={() => setCatFormWorkflow(prev => prev.filter((_, i) => i !== idx))}
-                          className="h-8 w-8 flex items-center justify-center text-slate-300 hover:text-rose-500 hover:bg-rose-50 rounded-xl transition-all shrink-0">
+                          className="h-8 w-8 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all shrink-0">
                           <Trash2 className="w-3.5 h-3.5" />
                         </button>
                       </div>
@@ -1436,7 +1436,7 @@ export default function AdminSettings() {
                       </div>
                       {step.approverType === 'approval_group' && (
                         <div className="space-y-1">
-                          <p className="text-[10px] text-slate-400 font-bold">グループメンバー</p>
+                          <p className="text-[10px] text-slate-500 font-bold">グループメンバー</p>
                           <div className="flex flex-wrap gap-1">
                             {users.filter(u => u.status === 'active').map(u => {
                               const selected = (step.approverGroupIds ?? []).includes(u.id);
@@ -1484,7 +1484,7 @@ export default function AdminSettings() {
           >
             <div className="p-6 border-b flex items-center justify-between">
               <h3 id="edit-user-modal-title" className="text-lg font-bold text-[#191714]">プロフィール編集</h3>
-              <button type="button" onClick={() => { setShowEditUserModal(false); setEditingUser(null); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-400" /></button>
+              <button type="button" onClick={() => { setShowEditUserModal(false); setEditingUser(null); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-500" /></button>
             </div>
             <div className="p-6 space-y-4">
               {[
@@ -1492,20 +1492,20 @@ export default function AdminSettings() {
                 { id: 'edit-user-email', label: 'メールアドレス', value: editUserEmail, setter: setEditUserEmail, placeholder: 'example@company.co.jp' },
               ].map(({ id, label, value, setter, placeholder }) => (
                 <div key={label} className="space-y-1">
-                  <label htmlFor={id} className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">{label}</label>
+                  <label htmlFor={id} className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">{label}</label>
                   <input id={id} type="text" value={value} onChange={e => setter(e.target.value)} placeholder={placeholder}
                     className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
                 </div>
               ))}
               <div className="space-y-1">
-                <label htmlFor="edit-user-position" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">役職</label>
+                <label htmlFor="edit-user-position" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">役職</label>
                 <select id="edit-user-position" value={editUserPosition} onChange={e => setEditUserPosition(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   {['President', 'Division Manager', 'General Manager', 'Team Leader', 'Member'].map(p => <option key={p} value={p}>{p}</option>)}
                 </select>
               </div>
               <div className="space-y-1">
-                <label htmlFor="edit-user-org-unit" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">組織ユニット</label>
+                <label htmlFor="edit-user-org-unit" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">組織ユニット</label>
                 <select id="edit-user-org-unit" value={editUserOrgUnit} onChange={e => setEditUserOrgUnit(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   {orgUnits.map(u => <option key={u.id} value={u.id}>{u.name}</option>)}
@@ -1526,7 +1526,7 @@ export default function AdminSettings() {
           <div className="bg-white w-full max-w-sm rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300">
             <div className="p-6 space-y-4">
               <div className="w-12 h-12 bg-rose-50 rounded-2xl flex items-center justify-center mx-auto">
-                <Trash2 className="w-6 h-6 text-rose-500" />
+                <Trash2 className="w-6 h-6 text-rose-600" />
               </div>
               <div className="text-center space-y-1">
                 <h3 className="text-base font-bold text-[#191714]">ユーザーを無効化しますか？</h3>
@@ -1554,16 +1554,16 @@ export default function AdminSettings() {
           >
             <div className="p-6 border-b flex items-center justify-between">
               <h3 id="unit-modal-title" className="text-lg font-bold text-[#191714]">{editingUnit ? 'ユニットを編集' : 'ユニットを追加'}</h3>
-              <button type="button" onClick={() => { setShowAddUnitModal(false); setEditingUnit(null); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-400" /></button>
+              <button type="button" onClick={() => { setShowAddUnitModal(false); setEditingUnit(null); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-500" /></button>
             </div>
             <div className="p-6 space-y-4">
               <div className="space-y-1">
-                <label htmlFor="unit-name" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">ユニット名</label>
+                <label htmlFor="unit-name" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">ユニット名</label>
                 <input id="unit-name" type="text" value={unitFormName} onChange={e => setUnitFormName(e.target.value)} placeholder="例: 営業第一グループ"
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
               </div>
               <div className="space-y-1">
-                <label htmlFor="unit-type" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">種別</label>
+                <label htmlFor="unit-type" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">種別</label>
                 <select id="unit-type" value={unitFormType} onChange={e => setUnitFormType(e.target.value as OrganizationUnit['type'])}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   <option value="division">Division（事業部）</option>
@@ -1572,7 +1572,7 @@ export default function AdminSettings() {
                 </select>
               </div>
               <div className="space-y-1">
-                <label htmlFor="unit-parent" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">親ユニット</label>
+                <label htmlFor="unit-parent" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">親ユニット</label>
                 <select id="unit-parent" value={unitFormParentId} onChange={e => setUnitFormParentId(e.target.value)}
                   className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
                   <option value="">なし（ルートとして追加）</option>
@@ -1596,7 +1596,7 @@ export default function AdminSettings() {
           <div className="bg-white w-full max-w-sm rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300">
             <div className="p-6 space-y-4">
               <div className="w-12 h-12 bg-rose-50 rounded-2xl flex items-center justify-center mx-auto">
-                <Trash2 className="w-6 h-6 text-rose-500" />
+                <Trash2 className="w-6 h-6 text-rose-600" />
               </div>
               <div className="text-center space-y-1">
                 <h3 className="text-base font-bold text-[#191714]">カテゴリーを削除しますか？</h3>

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -301,7 +301,7 @@ export default function RequestInbox() {
                 className="p-1.5 hover:bg-slate-200 rounded-lg transition-colors"
                 aria-label="CSVエクスポート"
               >
-                <Download className="w-4 h-4 text-slate-400" />
+                <Download className="w-4 h-4 text-slate-500" />
               </button>
               {/* Filter ドロップダウン（期間フィルター） */}
               <div className="relative">
@@ -309,13 +309,13 @@ export default function RequestInbox() {
                   onClick={() => { setShowFilterDropdown(v => !v); setShowSortDropdown(false); }}
                   className={cn("p-1.5 hover:bg-slate-200 rounded-lg transition-colors", (periodFilter !== 'all' || priorityFilter !== 'all' || categoryFilter !== 'all') && "bg-blue-50 text-blue-600")}
                 >
-                  <Filter className="w-4 h-4 text-slate-400" />
+                  <Filter className="w-4 h-4 text-slate-500" />
                 </button>
                 {showFilterDropdown && (
                   <>
                     <div className="fixed inset-0 z-[45]" onClick={() => setShowFilterDropdown(false)} />
                     <div className="absolute right-0 top-full mt-1 w-48 bg-white border rounded-xl shadow-xl z-50 overflow-hidden animate-in zoom-in-95 duration-150">
-                      <div className="px-3 py-1.5 text-[10px] font-black text-slate-400 uppercase tracking-widest border-b">期間</div>
+                      <div className="px-3 py-1.5 text-[10px] font-black text-slate-500 uppercase tracking-widest border-b">期間</div>
                       {([
                         { value: 'all', label: '全期間' },
                         { value: 'today', label: '今日' },
@@ -330,7 +330,7 @@ export default function RequestInbox() {
                           {opt.label}
                         </button>
                       ))}
-                      <div className="px-3 py-1.5 text-[10px] font-black text-slate-400 uppercase tracking-widest border-y mt-1">優先度</div>
+                      <div className="px-3 py-1.5 text-[10px] font-black text-slate-500 uppercase tracking-widest border-y mt-1">優先度</div>
                       {([
                         { value: 'all', label: 'すべて' },
                         { value: 'high', label: '急ぎ' },
@@ -347,7 +347,7 @@ export default function RequestInbox() {
                       ))}
                       {categories.length > 0 && (
                         <>
-                          <div className="px-3 py-1.5 text-[10px] font-black text-slate-400 uppercase tracking-widest border-y mt-1">カテゴリー</div>
+                          <div className="px-3 py-1.5 text-[10px] font-black text-slate-500 uppercase tracking-widest border-y mt-1">カテゴリー</div>
                           <button
                             onClick={() => { setCategoryFilter('all'); }}
                             className={cn("w-full text-left px-3 py-2 text-xs font-bold transition-colors hover:bg-slate-50", categoryFilter === 'all' ? "text-blue-600 bg-blue-50" : "text-slate-600")}
@@ -368,7 +368,7 @@ export default function RequestInbox() {
                       <div className="px-3 py-2 border-t">
                         <button
                           onClick={() => { setPeriodFilter('all'); setPriorityFilter('all'); setCategoryFilter('all'); setShowFilterDropdown(false); }}
-                          className="w-full text-center text-[10px] font-black text-slate-400 hover:text-slate-700 transition-colors uppercase tracking-widest"
+                          className="w-full text-center text-[10px] font-black text-slate-500 hover:text-slate-700 transition-colors uppercase tracking-widest"
                         >
                           リセット
                         </button>
@@ -383,13 +383,13 @@ export default function RequestInbox() {
                   onClick={() => { setShowSortDropdown(v => !v); setShowFilterDropdown(false); }}
                   className="p-1.5 hover:bg-slate-200 rounded-lg transition-colors"
                 >
-                  <MoreHorizontal className="w-4 h-4 text-slate-400" />
+                  <MoreHorizontal className="w-4 h-4 text-slate-500" />
                 </button>
                 {showSortDropdown && (
                   <>
                     <div className="fixed inset-0 z-[45]" onClick={() => setShowSortDropdown(false)} />
                     <div className="absolute right-0 top-full mt-1 w-36 bg-white border rounded-xl shadow-xl z-50 overflow-hidden animate-in zoom-in-95 duration-150">
-                      <div className="px-3 py-1.5 text-[10px] font-black text-slate-400 uppercase tracking-widest border-b">ソート順</div>
+                      <div className="px-3 py-1.5 text-[10px] font-black text-slate-500 uppercase tracking-widest border-b">ソート順</div>
                       {([
                         { value: 'newest', label: '新しい順' },
                         { value: 'oldest', label: '古い順' },
@@ -410,7 +410,7 @@ export default function RequestInbox() {
             </div>
           </div>
           <div className="relative">
-            <Search className="absolute left-3 top-2.5 w-4 h-4 text-slate-300" />
+            <Search className="absolute left-3 top-2.5 w-4 h-4 text-slate-500" />
             <input
               type="text"
               aria-label="依頼を検索"
@@ -431,7 +431,7 @@ export default function RequestInbox() {
                   onClick={() => setFilter(currentStatus)}
                   className={cn(
                     "px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-widest border transition-all whitespace-nowrap",
-                    isActive ? "bg-slate-900 text-white border-slate-900" : "bg-white text-slate-400 border-slate-200 hover:border-slate-400"
+                    isActive ? "bg-slate-900 text-white border-slate-900" : "bg-white text-slate-500 border-slate-200 hover:border-slate-400"
                   )}
                 >
                   {label}
@@ -456,14 +456,14 @@ export default function RequestInbox() {
               >
                 <div className="flex items-center justify-between mb-1">
                   <div className="flex items-center gap-1.5 min-w-0">
-                    <span className="text-[10px] font-black text-slate-400 uppercase tracking-widest truncate">{task.category}</span>
+                    <span className="text-[10px] font-black text-slate-500 uppercase tracking-widest truncate">{task.category}</span>
                     {task.taskType === 'circulation' && (
-                      <span className="shrink-0 px-1.5 py-0.5 rounded-full text-[8px] font-black bg-teal-50 text-teal-600 border border-teal-100">回覧</span>
+                      <span className="shrink-0 px-1.5 py-0.5 rounded-full text-[8px] font-black bg-teal-50 text-teal-700 border border-teal-100">回覧</span>
                     )}
                   </div>
                   <span className={cn(
                     "shrink-0 px-2 py-0.5 rounded-full text-[9px] font-black uppercase tracking-tight",
-                    isOverdue ? "bg-rose-100 text-rose-600" :
+                    isOverdue ? "bg-rose-100 text-rose-700" :
                     task.status === 'completed' ? "bg-emerald-50 text-emerald-600" :
                     task.status === 'in_progress' ? "bg-blue-50 text-blue-600" :
                     "bg-slate-100 text-slate-500"
@@ -475,7 +475,7 @@ export default function RequestInbox() {
                 
                 {/* Current Holder Display */}
                 <div className="flex items-center gap-1.5 mt-2 mb-2">
-                  <span className="text-[9px] font-bold text-slate-400">現在：</span>
+                  <span className="text-[9px] font-bold text-slate-500">現在：</span>
                   <span className={cn(
                     "px-1.5 py-0.5 rounded text-[9px] font-bold",
                     task.currentApproverId === user?.id ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-600"
@@ -487,20 +487,20 @@ export default function RequestInbox() {
                 <div className="flex items-center gap-3">
                   <div className="flex items-center gap-1.5">
                     <div className="w-4 h-4 rounded-full bg-slate-200 flex items-center justify-center text-[8px] font-bold">U</div>
-                    <span className="text-[10px] font-bold text-slate-400">{task.requesterId.split('_').pop()}</span>
+                    <span className="text-[10px] font-bold text-slate-500">{task.requesterId.split('_').pop()}</span>
                   </div>
                   <div className="flex items-center gap-1.5 ml-auto">
                     {isOverdue && (() => {
                       const days = Math.floor((now.getTime() - new Date(task.dueDate).getTime()) / 86400000);
                       return (
-                        <span className="text-[8px] font-black bg-rose-100 text-rose-600 px-1.5 py-0.5 rounded-full border border-rose-200">
+                        <span className="text-[8px] font-black bg-rose-100 text-rose-700 px-1.5 py-0.5 rounded-full border border-rose-200">
                           +{days}日超過
                         </span>
                       );
                     })()}
                     <div className={cn(
                       "text-[10px] font-bold",
-                      isOverdue ? "text-rose-500" : "text-slate-300"
+                      isOverdue ? "text-rose-700" : "text-slate-500"
                     )}>
                       <ClientOnlyDate date={task.dueDate} />
                     </div>
@@ -526,14 +526,14 @@ export default function RequestInbox() {
             <div className="p-6 border-b flex items-center justify-between">
               <h3 id="reject-modal-title" className="text-lg font-bold text-[#191714]">差し戻し理由を入力</h3>
               <button type="button" onClick={() => setShowRejectModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
-                <X className="w-5 h-5 text-slate-400" />
+                <X className="w-5 h-5 text-slate-500" />
               </button>
             </div>
             <div className="p-6 space-y-5">
               <p className="text-sm text-slate-500 font-medium">申請者に差し戻す理由を入力してください。コメントは必須です。</p>
               {/* 定型テンプレート */}
               <div className="space-y-2">
-                <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">定型テンプレート</p>
+                <p className="text-[10px] font-black text-slate-500 uppercase tracking-widest">定型テンプレート</p>
                 <div className="flex flex-wrap gap-2">
                   {[
                     '内容を修正して再申請してください',
@@ -593,7 +593,7 @@ export default function RequestInbox() {
             <div className="p-6 border-b flex items-center justify-between">
               <h3 id="change-approver-modal-title" className="text-lg font-bold text-[#191714]">承認者を変更</h3>
               <button type="button" onClick={() => setShowChangeApproverModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
-                <X className="w-5 h-5 text-slate-400" />
+                <X className="w-5 h-5 text-slate-500" />
               </button>
             </div>
             <div className="p-6 space-y-4">
@@ -601,7 +601,7 @@ export default function RequestInbox() {
                 ステップ {changingStepIndex + 1} の承認者を変更します。現在: <span className="font-bold text-slate-800">{selectedTask?.approvalRoute[changingStepIndex]?.userName}</span>
               </p>
               <div className="relative">
-                <Search className="absolute left-3 top-2.5 w-4 h-4 text-slate-300" />
+                <Search className="absolute left-3 top-2.5 w-4 h-4 text-slate-500" />
                 <input
                   type="text"
                   aria-label="承認者を検索"
@@ -625,11 +625,11 @@ export default function RequestInbox() {
                     >
                       {u.avatar
                         ? <Image src={u.avatar} width={32} height={32} alt={u.name} className="w-8 h-8 rounded-lg bg-slate-100 border border-slate-100 group-hover:border-slate-300" />
-                        : <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center text-xs font-bold text-slate-400">{u.name[0]}</div>
+                        : <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center text-xs font-bold text-slate-500">{u.name[0]}</div>
                       }
                       <div>
                         <div className="text-sm font-bold text-slate-800">{u.name}</div>
-                        <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{u.position}</div>
+                        <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">{u.position}</div>
                       </div>
                     </button>
                   ))
@@ -671,7 +671,7 @@ export default function RequestInbox() {
                 )}>
                   <AlarmClock className={cn(
                     "w-4 h-4 mt-0.5 shrink-0",
-                    urgency === 'critical' ? "text-rose-500" : urgency === 'high' ? "text-orange-500" : "text-amber-500"
+                    urgency === 'critical' ? "text-rose-600" : urgency === 'high' ? "text-orange-600" : "text-amber-600"
                   )} />
                   <div className="flex-1 min-w-0">
                     <p className={cn(
@@ -683,7 +683,7 @@ export default function RequestInbox() {
                     </p>
                     <p className={cn(
                       "text-[10px] font-medium mt-0.5",
-                      urgency === 'critical' ? "text-rose-500" : urgency === 'high' ? "text-orange-500" : "text-amber-500"
+                      urgency === 'critical' ? "text-rose-700" : urgency === 'high' ? "text-orange-700" : "text-amber-700"
                     )}>
                       期限: <ClientOnlyDate date={selectedTask.dueDate} /> ／ 現在の担当者が未処理のため遅延しています
                     </p>
@@ -702,7 +702,7 @@ export default function RequestInbox() {
                       回覧
                     </span>
                   )}
-                  <span className="text-[10px] font-bold text-slate-300">ID: {selectedTask.id}</span>
+                  <span className="text-[10px] font-bold text-slate-500">ID: {selectedTask.id}</span>
                 </div>
                 <button
                   onClick={handleExportPdf}
@@ -719,16 +719,16 @@ export default function RequestInbox() {
               </h1>
               <div className="flex items-center gap-6 py-2 border-y border-slate-100">
                 <div className="space-y-1">
-                  <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">申請者</div>
+                  <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">申請者</div>
                   <div className="flex items-center gap-2">
                     <div className="w-6 h-6 rounded-lg bg-slate-100 flex items-center justify-center text-xs font-bold">U</div>
                     <span className="text-xs font-bold text-[#191714]">User {selectedTask.requesterId.split('_').pop()}</span>
                   </div>
                 </div>
                 <div className="space-y-1">
-                  <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">期限 (SLA)</div>
+                  <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">期限 (SLA)</div>
                   <div className="flex items-center gap-2">
-                    <Calendar className="w-4 h-4 text-slate-300" />
+                    <Calendar className="w-4 h-4 text-slate-500" />
                     <span className="text-xs font-bold text-[#191714]"><ClientOnlyDate date={selectedTask.dueDate} /></span>
                   </div>
                 </div>
@@ -736,12 +736,12 @@ export default function RequestInbox() {
             </header>
 
             <section className="space-y-4">
-              <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+              <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
                 <FileText className="w-4 h-4" />
                 依頼内容の詳細
               </h3>
               <div className="text-sm font-medium text-slate-600 leading-relaxed bg-slate-50/50 p-6 rounded-2xl border border-slate-100">
-                {selectedTask.description || <span className="text-slate-400 italic">追加の説明はありません。</span>}
+                {selectedTask.description || <span className="text-slate-500 italic">追加の説明はありません。</span>}
               </div>
               
               {/* Dynamic Form Custom Data Rendering */}
@@ -751,7 +751,7 @@ export default function RequestInbox() {
                   <div className="grid grid-cols-2 gap-y-4">
                     {Object.entries(selectedTask.customData).map(([key, value]) => (
                       <div key={key} className="space-y-1">
-                        <div className="text-[10px] font-bold text-slate-400 uppercase">{key}</div>
+                        <div className="text-[10px] font-bold text-slate-500 uppercase">{key}</div>
                         <div className="text-sm font-bold text-[#191714]">{value as string}</div>
                       </div>
                     ))}
@@ -763,7 +763,7 @@ export default function RequestInbox() {
             {/* Approval Route Visual */}
             <section className="space-y-6">
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+                <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
                   <ShieldCheck className="w-4 h-4" />
                   現在の承認ステータス
                 </h3>
@@ -824,7 +824,7 @@ export default function RequestInbox() {
                         ? <Image src={step.avatar} width={40} height={40} alt={step.userName} className="w-10 h-10 rounded-xl bg-slate-100 mb-3 mt-2" />
                         : <div className="w-10 h-10 rounded-xl bg-slate-100 mb-3 mt-2" />
                       }
-                      <div className="text-[9px] font-bold text-slate-400 uppercase tracking-widest leading-none mb-1">{step.position}</div>
+                      <div className="text-[9px] font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">{step.position}</div>
                       <div className="text-xs font-bold text-[#191714]">{step.userName}</div>
                       {isDelegated && delegateUser && (
                         <div className="text-[9px] font-bold text-violet-500 mt-0.5">代理: {delegateUser.name}</div>
@@ -834,14 +834,14 @@ export default function RequestInbox() {
                           "text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border",
                           step.status === 'approved' ? "bg-emerald-50 text-emerald-600 border-emerald-100" :
                           step.status === 'rejected' ? "bg-rose-50 text-rose-500 border-rose-100" :
-                          "bg-slate-50 text-slate-400 border-slate-100"
+                          "bg-slate-50 text-slate-500 border-slate-100"
                         )}>
                           {stepLabel}
                         </span>
                         {step.status === 'pending' && (
                           <button
                             onClick={() => handleOpenChangeApprover(idx)}
-                            className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border border-slate-200 text-slate-400 hover:border-blue-400 hover:text-blue-600 hover:bg-blue-50 transition-all"
+                            className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border border-slate-200 text-slate-500 hover:border-blue-400 hover:text-blue-600 hover:bg-blue-50 transition-all"
                             aria-label={`${step.userName}の承認者を変更`}
                           >
                             変更
@@ -857,7 +857,7 @@ export default function RequestInbox() {
               {selectedTask.ccRoute && selectedTask.ccRoute.length > 0 && (
                 <div className="pt-2 animate-in fade-in duration-500">
                   <div className="flex items-center gap-2 mb-3">
-                    <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">CC（共有先）</div>
+                    <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">CC（共有先）</div>
                     <div className="h-px flex-1 bg-slate-100" />
                   </div>
                   <div className="flex flex-wrap gap-2">
@@ -869,7 +869,7 @@ export default function RequestInbox() {
                         }
                         <div className="flex flex-col">
                           <span className="text-[10px] font-bold text-[#191714] leading-tight">{cc.userName}</span>
-                          <span className="text-[8px] font-medium text-slate-400 leading-tight uppercase tracking-tighter">{cc.position}</span>
+                          <span className="text-[8px] font-medium text-slate-500 leading-tight uppercase tracking-tighter">{cc.position}</span>
                         </div>
                       </div>
                     ))}
@@ -880,7 +880,7 @@ export default function RequestInbox() {
 
             {/* Audit Logs (Timeline) */}
             <section className="space-y-6">
-              <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+              <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
                 <History className="w-4 h-4" />
                 アクティビティ履歴
               </h3>
@@ -917,7 +917,7 @@ export default function RequestInbox() {
                               {theme.label}
                             </span>
                           </div>
-                          <div className="text-[10px] font-bold text-slate-300">
+                          <div className="text-[10px] font-bold text-slate-500">
                             <ClientOnlyDate date={log.timestamp} showTime />
                           </div>
                         </div>
@@ -928,14 +928,14 @@ export default function RequestInbox() {
                     </div>
                   );
                 }) : (
-                  <div className="text-[10px] font-bold text-slate-300 uppercase tracking-widest italic py-4">履歴データはまだありません</div>
+                  <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest italic py-4">履歴データはまだありません</div>
                 )}
               </div>
             </section>
 
             {/* In-App Messaging (Comments) */}
             <section className="space-y-6 pt-4 border-t">
-              <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+              <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
                 <MessageSquare className="w-4 h-4" />
                 連絡・コメントを追加
               </h3>
@@ -1016,7 +1016,7 @@ export default function RequestInbox() {
                     </button>
                   </>
                 ) : (
-                  <div className="flex-1 py-4 text-center text-sm font-bold text-slate-300 border border-dashed rounded-2xl">
+                  <div className="flex-1 py-4 text-center text-sm font-bold text-slate-500 border border-dashed rounded-2xl">
                     現在あなたの対応番ではありません
                   </div>
                 )}
@@ -1024,7 +1024,7 @@ export default function RequestInbox() {
             </footer>
           </div>
         ) : (
-          <div className="h-full flex flex-col items-center justify-center text-slate-300">
+          <div className="h-full flex flex-col items-center justify-center text-slate-500">
             <Archive className="w-16 h-16 opacity-10 mb-4" />
             <p className="text-sm font-bold uppercase tracking-widest opacity-30">依頼を選択してください</p>
           </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -73,11 +73,11 @@ export default function LoginPage() {
           <div className="grid grid-cols-2 gap-4">
             <div className="p-4 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10">
               <div className="text-2xl font-bold text-white mb-1">147+</div>
-              <div className="text-xs font-bold text-slate-400 uppercase tracking-widest">Active Users</div>
+              <div className="text-xs font-bold text-slate-500 uppercase tracking-widest">Active Users</div>
             </div>
             <div className="p-4 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10">
               <div className="text-2xl font-bold text-white mb-1">27+</div>
-              <div className="text-xs font-bold text-slate-400 uppercase tracking-widest">Teams</div>
+              <div className="text-xs font-bold text-slate-500 uppercase tracking-widest">Teams</div>
             </div>
           </div>
         </div>
@@ -110,7 +110,7 @@ export default function LoginPage() {
                 value={email}
                 onChange={e => setEmail(e.target.value)}
                 placeholder="user@example.com"
-                className="w-full px-4 py-3 border border-slate-300 rounded-xl text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                className="w-full px-4 py-3 border border-slate-300 rounded-xl text-slate-900 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
               />
             </div>
             {!isMockMode && (
@@ -125,7 +125,7 @@ export default function LoginPage() {
                   value={password}
                   onChange={e => setPassword(e.target.value)}
                   placeholder="••••••••"
-                  className="w-full px-4 py-3 border border-slate-300 rounded-xl text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-4 py-3 border border-slate-300 rounded-xl text-slate-900 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
                 />
               </div>
             )}
@@ -149,7 +149,7 @@ export default function LoginPage() {
             <>
               <div className="my-6 flex items-center gap-3">
                 <div className="flex-1 h-px bg-slate-200" />
-                <span className="text-xs text-slate-400 font-bold uppercase tracking-widest whitespace-nowrap">デモ（ワンクリック）</span>
+                <span className="text-xs text-slate-500 font-bold uppercase tracking-widest whitespace-nowrap">デモ（ワンクリック）</span>
                 <div className="flex-1 h-px bg-slate-200" />
               </div>
 
@@ -165,9 +165,9 @@ export default function LoginPage() {
                       <u.icon className="w-6 h-6" />
                     </div>
                     <div className="flex-1">
-                      <div className="text-xs font-bold text-slate-400 uppercase tracking-widest leading-none mb-1">{u.label}</div>
+                      <div className="text-xs font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">{u.label}</div>
                       <div className="text-base font-bold text-slate-900">{u.name}</div>
-                      <div className="text-xs text-slate-400">{u.email}</div>
+                      <div className="text-xs text-slate-500">{u.email}</div>
                     </div>
                     <div className="w-8 h-8 rounded-full bg-slate-50 flex items-center justify-center group-hover:bg-slate-900 group-hover:text-white transition-colors">
                       <LayoutDashboard className="w-4 h-4" />
@@ -178,7 +178,7 @@ export default function LoginPage() {
             </>
           )}
 
-          <p className="mt-8 text-center text-xs text-slate-400 font-bold uppercase tracking-widest">
+          <p className="mt-8 text-center text-xs text-slate-500 font-bold uppercase tracking-widest">
             {isMockMode ? 'Mock Mode — No Database Connection' : 'Powered by Supabase Auth'}
           </p>
         </div>

--- a/src/app/organization/page.tsx
+++ b/src/app/organization/page.tsx
@@ -74,7 +74,7 @@ export default function OrganizationPage() {
       <div className="flex items-center justify-center min-h-[60vh]">
         <div className="flex flex-col items-center gap-4">
           <div className="w-10 h-10 border-4 border-slate-100 border-t-slate-900 rounded-full animate-spin" />
-          <p className="text-xs font-bold text-slate-400 uppercase tracking-widest animate-pulse">Building Organization Map...</p>
+          <p className="text-xs font-bold text-slate-500 uppercase tracking-widest animate-pulse">Building Organization Map...</p>
         </div>
       </div>
     );
@@ -85,7 +85,7 @@ export default function OrganizationPage() {
       {/* Header Section */}
       <header className="mb-10 flex flex-col md:flex-row md:items-end justify-between gap-6">
         <div className="space-y-1">
-          <div className="flex items-center gap-2 text-slate-400">
+          <div className="flex items-center gap-2 text-slate-500">
             <Building2 className="w-4 h-4" />
             <span className="text-[10px] font-black uppercase tracking-widest">Workspace Directory</span>
           </div>
@@ -95,7 +95,7 @@ export default function OrganizationPage() {
 
         {/* Search Bar */}
         <div className="relative w-full md:w-80 group">
-          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 group-focus-within:text-slate-900 transition-colors" />
+          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500 group-focus-within:text-slate-900 transition-colors" />
           <input 
             type="text" 
             placeholder="氏名、役職、メールアドレスで検索..." 
@@ -108,7 +108,7 @@ export default function OrganizationPage() {
               onClick={() => { setSearchQuery(''); setDebouncedQuery(''); }}
               className="absolute right-4 top-1/2 -translate-y-1/2 p-1 hover:bg-slate-100 rounded-lg transition-colors"
             >
-              <X className="w-3 h-3 text-slate-400" />
+              <X className="w-3 h-3 text-slate-500" />
             </button>
           )}
         </div>
@@ -126,7 +126,7 @@ export default function OrganizationPage() {
                 <Target className="w-5 h-5 text-slate-900" />
                 <h2 className="text-lg font-bold text-slate-900">組織構造</h2>
               </div>
-              <div className="flex items-center gap-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">
+              <div className="flex items-center gap-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">
                 <div className="flex items-center gap-1.5">
                   <div className="w-2 h-2 bg-slate-900 rounded-full border border-white shadow-sm" />
                   <span>管理者</span>
@@ -187,7 +187,7 @@ export default function OrganizationPage() {
                         <span className="px-2 py-0.5 bg-white/10 border border-white/20 rounded-full text-[10px] font-black uppercase tracking-tighter">System Admin</span>
                       )}
                     </div>
-                    <p className="text-slate-400 font-bold uppercase tracking-widest text-xs mt-1">{selectedUser.position}</p>
+                    <p className="text-slate-500 font-bold uppercase tracking-widest text-xs mt-1">{selectedUser.position}</p>
                   </div>
                 </div>
 
@@ -199,7 +199,7 @@ export default function OrganizationPage() {
                         <Mail className="w-4 h-4 text-slate-500 group-hover:text-white transition-colors" />
                         <span className="text-sm font-bold truncate">{selectedUser.email}</span>
                       </div>
-                      <div className="flex items-center gap-3 text-slate-400">
+                      <div className="flex items-center gap-3 text-slate-500">
                         <Phone className="w-4 h-4 text-slate-500" />
                         <span className="text-sm font-bold">03-XXXX-XXXX (内線 123)</span>
                       </div>
@@ -209,7 +209,7 @@ export default function OrganizationPage() {
                   <div className="space-y-4">
                     <h4 className="text-[10px] font-black text-slate-500 uppercase tracking-widest border-b border-white/10 pb-2">Managed Responsibilities</h4>
                     <div className="space-y-3">
-                      <div className="flex items-center gap-3 text-slate-400">
+                      <div className="flex items-center gap-3 text-slate-500">
                         <MapPin className="w-4 h-4 text-slate-500" />
                         <span className="text-sm font-bold">本社オフィス (東京)</span>
                       </div>
@@ -250,7 +250,7 @@ export default function OrganizationPage() {
             <div className="p-6 border-b flex items-center justify-between">
               <h3 id="profile-modal-title" className="text-lg font-bold text-[#191714]">プロフィール詳細</h3>
               <button type="button" onClick={() => setShowProfileModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
-                <X className="w-5 h-5 text-slate-400" />
+                <X className="w-5 h-5 text-slate-500" />
               </button>
             </div>
             <div className="p-6 space-y-5">
@@ -261,7 +261,7 @@ export default function OrganizationPage() {
                 }
                 <div>
                   <div className="text-xl font-black text-[#191714]">{selectedUser.name}</div>
-                  <div className="text-xs font-bold text-slate-400 uppercase tracking-widest">{selectedUser.position}</div>
+                  <div className="text-xs font-bold text-slate-500 uppercase tracking-widest">{selectedUser.position}</div>
                 </div>
               </div>
               <div className="space-y-2 text-sm">
@@ -274,7 +274,7 @@ export default function OrganizationPage() {
                   { label: 'システムロール', value: selectedUser.role === 'admin' ? '管理者' : '一般ユーザー' },
                 ].map(row => (
                   <div key={row.label} className="flex justify-between py-2 border-b border-slate-50">
-                    <span className="text-slate-400 font-bold text-xs uppercase tracking-widest">{row.label}</span>
+                    <span className="text-slate-500 font-bold text-xs uppercase tracking-widest">{row.label}</span>
                     <span className="font-bold text-[#191714]">{row.value}</span>
                   </div>
                 ))}
@@ -290,7 +290,7 @@ export default function OrganizationPage() {
           <div className="max-w-4xl mx-auto px-6 py-10 h-full overflow-y-auto">
             <div className="flex items-center justify-between mb-8">
               <h3 className="text-2xl font-black tracking-tight text-slate-900">
-                検索結果: <span className="text-slate-400">{filteredUsers.length}件</span>
+                検索結果: <span className="text-slate-500">{filteredUsers.length}件</span>
               </h3>
               <button
                 onClick={() => { setSearchQuery(''); setDebouncedQuery(''); }}
@@ -328,17 +328,17 @@ export default function OrganizationPage() {
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-bold text-slate-900">{u.name}</span>
                         {u.role === 'admin' && (
-                           <span className="text-[8px] font-black uppercase text-slate-400 bg-slate-50 px-1 py-0.5 rounded border border-slate-100">Admin</span>
+                           <span className="text-[8px] font-black uppercase text-slate-500 bg-slate-50 px-1 py-0.5 rounded border border-slate-100">Admin</span>
                         )}
                       </div>
-                      <span className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{u.position}</span>
+                      <span className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">{u.position}</span>
                     </div>
                     <ChevronRight className="ml-auto w-4 h-4 text-slate-200 group-hover:text-slate-900 group-hover:translate-x-1 transition-all" />
                   </div>
                 ))}
               </div>
             ) : (
-              <div className="flex flex-col items-center justify-center py-20 text-slate-400">
+              <div className="flex flex-col items-center justify-center py-20 text-slate-500">
                 <Search className="w-12 h-12 mb-4 opacity-10" />
                 <p className="font-bold uppercase tracking-widest text-xs">No matching members found</p>
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -194,7 +194,7 @@ export default function Dashboard() {
           {/* Advanced Filters */}
           <div className="bg-white p-4 rounded-2xl border border-slate-200 notion-shadow flex flex-wrap items-center gap-6">
             <div className="flex items-center gap-3">
-              <Calendar className="w-4 h-4 text-slate-400" />
+              <Calendar className="w-4 h-4 text-slate-500" />
               <div className="flex items-center gap-2">
                 <input type="date" className="text-xs font-bold bg-slate-50 border rounded-lg px-2 py-1.5" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
                 <span className="text-slate-300 font-bold">~</span>
@@ -202,7 +202,7 @@ export default function Dashboard() {
               </div>
             </div>
             <div className="flex items-center gap-3 border-l pl-8">
-              <Filter className="w-4 h-4 text-slate-400" />
+              <Filter className="w-4 h-4 text-slate-500" />
               <select className="text-xs font-bold bg-slate-50 border rounded-lg px-4 py-1.5" value={selectedDeptId} onChange={(e) => setSelectedDeptId(e.target.value)}>
                 <option value="all">すべての管理部門</option>
                 {departments.map(d => <option key={d.id} value={d.id}>{d.name}</option>)}
@@ -254,7 +254,7 @@ export default function Dashboard() {
                 選択中 {selectedTaskIds.size} 件を一括承認
               </button>
             )}
-            <span className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{myTurnTasks.length}件</span>
+            <span className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">{myTurnTasks.length}件</span>
           </div>
         </div>
         
@@ -271,10 +271,10 @@ export default function Dashboard() {
                       className="w-4 h-4 rounded cursor-pointer accent-slate-900"
                     />
                   </th>
-                  <th className="px-6 py-4 text-[10px] font-black text-slate-400 uppercase tracking-widest">申請内容</th>
-                  <th className="px-6 py-4 text-[10px] font-black text-slate-400 uppercase tracking-widest">申請者</th>
-                  <th className="px-6 py-4 text-[10px] font-black text-slate-400 uppercase tracking-widest text-center">回答期限</th>
-                  <th className="px-6 py-4 text-[10px] font-black text-slate-400 uppercase tracking-widest text-right">アクション</th>
+                  <th className="px-6 py-4 text-[10px] font-black text-slate-500 uppercase tracking-widest">申請内容</th>
+                  <th className="px-6 py-4 text-[10px] font-black text-slate-500 uppercase tracking-widest">申請者</th>
+                  <th className="px-6 py-4 text-[10px] font-black text-slate-500 uppercase tracking-widest text-center">回答期限</th>
+                  <th className="px-6 py-4 text-[10px] font-black text-slate-500 uppercase tracking-widest text-right">アクション</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100">
@@ -291,7 +291,7 @@ export default function Dashboard() {
                     <td className="px-6 py-4">
                       <Link href={`/inbox?taskId=${t.id}`} className="block">
                         <div className="text-sm font-bold text-slate-800">{t.title}</div>
-                        <div className="text-[10px] text-slate-400 line-clamp-1">{t.description}</div>
+                        <div className="text-[10px] text-slate-500 line-clamp-1">{t.description}</div>
                       </Link>
                     </td>
                     <td className="px-6 py-4">
@@ -306,7 +306,7 @@ export default function Dashboard() {
                       </div>
                     </td>
                     <td className="px-6 py-4 text-center">
-                      <span className="text-[10px] font-black text-rose-500 flex items-center justify-center gap-1">
+                      <span className="text-[10px] font-black text-rose-700 flex items-center justify-center gap-1">
                         <Clock className="w-3 h-3" />
                         <ClientOnlyDate date={t.dueDate} />
                       </span>
@@ -323,7 +323,7 @@ export default function Dashboard() {
             </table>
           </div>
         ) : (
-          <div className="bg-slate-50 border p-10 rounded-3xl text-center border-dashed text-slate-400 text-xs font-bold uppercase tracking-widest">
+          <div className="bg-slate-50 border p-10 rounded-3xl text-center border-dashed text-slate-500 text-xs font-bold uppercase tracking-widest">
              現在対応すべきタスクはありません。
           </div>
         )}
@@ -337,9 +337,9 @@ export default function Dashboard() {
             <table className="w-full text-left">
               <thead className="bg-slate-50/50 border-b">
                 <tr>
-                  <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">申請内容</th>
-                  <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">ステータス</th>
-                  <th className="px-6 py-4 text-[10px] font-bold text-slate-400 uppercase tracking-widest">現在の担当者</th>
+                  <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">申請内容</th>
+                  <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">ステータス</th>
+                  <th className="px-6 py-4 text-[10px] font-bold text-slate-500 uppercase tracking-widest">現在の担当者</th>
                   <th className="w-10"></th>
                 </tr>
               </thead>
@@ -348,7 +348,7 @@ export default function Dashboard() {
                   <tr key={task.id} className="hover:bg-slate-50/50">
                     <td className="px-6 py-4">
                       <div className="font-bold text-sm mb-0.5">{task.title}</div>
-                      <div className="text-[10px] font-bold text-slate-300">{new Date(task.createdAt).toLocaleDateString('ja-JP')} 提出</div>
+                      <div className="text-[10px] font-bold text-slate-500">{new Date(task.createdAt).toLocaleDateString('ja-JP')} 提出</div>
                     </td>
                     <td className="px-6 py-4">
                       <span className="px-2.5 py-1 rounded-full text-[10px] font-black uppercase bg-blue-50 text-blue-600 border border-blue-100 italic">
@@ -359,14 +359,14 @@ export default function Dashboard() {
                       <span className="text-xs font-bold text-slate-600">{task.currentApproverName || 'Next...'}</span>
                     </td>
                     <td className="pr-4 text-right">
-                      <Link href="/tracker" className="text-slate-300 hover:text-slate-900"><ChevronRight className="w-4 h-4" /></Link>
+                      <Link href="/tracker" className="text-slate-500 hover:text-slate-900"><ChevronRight className="w-4 h-4" /></Link>
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
           ) : (
-            <div className="p-10 text-center text-slate-300 text-xs font-bold uppercase tracking-widest">
+            <div className="p-10 text-center text-slate-500 text-xs font-bold uppercase tracking-widest">
               進行中の申請はありません。
             </div>
           )}
@@ -377,11 +377,11 @@ export default function Dashboard() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <Link href="/request" className="flex items-center gap-3 p-5 bg-slate-900 text-white rounded-2xl hover:bg-black group shadow-xl">
            <div className="w-9 h-9 rounded-xl bg-white/10 flex items-center justify-center"><Plus className="w-5 h-5" /></div>
-           <div><div className="text-sm font-bold">新規依頼を作成</div><p className="text-[10px] text-slate-400">Apply for anything</p></div>
+           <div><div className="text-sm font-bold">新規依頼を作成</div><p className="text-[10px] text-slate-500">Apply for anything</p></div>
         </Link>
         <Link href="/tracker" className="flex items-center gap-3 p-5 bg-white border border-slate-200 rounded-2xl hover:border-slate-900 group">
-           <div className="w-9 h-9 rounded-xl bg-slate-50 flex items-center justify-center text-slate-400 group-hover:bg-slate-900 group-hover:text-white"><BarChart3 className="w-5 h-5" /></div>
-           <div><div className="text-sm font-bold text-slate-900">全ての履歴を確認</div><p className="text-[10px] text-slate-400">Audit your process</p></div>
+           <div className="w-9 h-9 rounded-xl bg-slate-50 flex items-center justify-center text-slate-500 group-hover:bg-slate-900 group-hover:text-white"><BarChart3 className="w-5 h-5" /></div>
+           <div><div className="text-sm font-bold text-slate-900">全ての履歴を確認</div><p className="text-[10px] text-slate-500">Audit your process</p></div>
         </Link>
       </div>
     </div>
@@ -403,7 +403,7 @@ function StatsCard({ icon, title, value, color, percent }: { icon: React.ReactNo
           <div className={`w-8 h-8 rounded-xl flex items-center justify-center ${colorMap[color].split(' ')[2]} ${colorMap[color].split(' ')[1]}`}>
             {icon}
           </div>
-          <h4 className="text-xs font-black text-slate-400 uppercase tracking-widest">{title}</h4>
+          <h4 className="text-xs font-black text-slate-500 uppercase tracking-widest">{title}</h4>
         </div>
         <span className={`text-2xl font-black ${colorMap[color].split(' ')[1]}`}>{value}</span>
       </div>

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -518,8 +518,8 @@ function RequestFormContent() {
             }`}
             aria-pressed={taskType === opt.value}
           >
-            <div className={`text-xs font-black ${taskType === opt.value ? 'text-slate-900' : 'text-slate-400'}`}>{opt.label}</div>
-            <div className="text-[10px] text-slate-400 font-medium mt-0.5">{opt.desc}</div>
+            <div className={`text-xs font-black ${taskType === opt.value ? 'text-slate-900' : 'text-slate-500'}`}>{opt.label}</div>
+            <div className="text-[10px] text-slate-500 font-medium mt-0.5">{opt.desc}</div>
           </button>
         ))}
       </div>
@@ -528,13 +528,13 @@ function RequestFormContent() {
         <div className="lg:col-span-2 space-y-6">
           {/* Section 1: Categories */}
           <section className="space-y-4">
-            <div className="flex items-center gap-2 text-xs font-bold text-slate-400 uppercase tracking-widest">
+            <div className="flex items-center gap-2 text-xs font-bold text-slate-500 uppercase tracking-widest">
               <span className="w-5 h-5 rounded bg-slate-100 flex items-center justify-center text-slate-900 border">1</span>
               カテゴリー選択
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <label htmlFor="req-large-category" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">大分類</label>
+                <label htmlFor="req-large-category" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">大分類</label>
                 <div className="relative group">
                   <select
                     id="req-large-category"
@@ -548,11 +548,11 @@ function RequestFormContent() {
                     <option value="">選択してください</option>
                     {largeCategoryOptions.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
                   </select>
-                  <ChevronDown className="absolute right-3 top-3.5 w-5 h-5 text-slate-400 pointer-events-none group-hover:text-slate-600 transition-colors" />
+                  <ChevronDown className="absolute right-3 top-3.5 w-5 h-5 text-slate-500 pointer-events-none group-hover:text-slate-600 transition-colors" />
                 </div>
               </div>
               <div className="space-y-2">
-                <label htmlFor="req-medium-category" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">中分類</label>
+                <label htmlFor="req-medium-category" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">中分類</label>
                 <div className="relative group">
                   <select
                     id="req-medium-category"
@@ -569,7 +569,7 @@ function RequestFormContent() {
                     <option value="">選択してください</option>
                     {mediumCategoryOptions.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
                   </select>
-                  <ChevronDown className="absolute right-3 top-3.5 w-5 h-5 text-slate-400 pointer-events-none group-hover:text-slate-600 transition-colors" />
+                  <ChevronDown className="absolute right-3 top-3.5 w-5 h-5 text-slate-500 pointer-events-none group-hover:text-slate-600 transition-colors" />
                 </div>
               </div>
             </div>
@@ -591,19 +591,19 @@ function RequestFormContent() {
 
           {/* Section 2: Details */}
           <section className="space-y-4">
-            <div className="flex items-center gap-2 text-xs font-bold text-slate-400 uppercase tracking-widest">
+            <div className="flex items-center gap-2 text-xs font-bold text-slate-500 uppercase tracking-widest">
               <span className="w-5 h-5 rounded bg-slate-100 flex items-center justify-center text-slate-900 border">2</span>
               申請内容の詳細
             </div>
             <div className="space-y-4">
               {/* A-1: 優先度 */}
               <div className="space-y-2">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">優先度</label>
+                <label className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">優先度</label>
                 <div className="flex gap-2">
                   {([
                     { value: 'low',    label: '低',   className: 'border-sky-200 text-sky-500 bg-sky-50' },
                     { value: 'normal', label: '通常', className: 'border-slate-200 text-slate-500 bg-slate-50' },
-                    { value: 'high',   label: '急ぎ', className: 'border-rose-200 text-rose-500 bg-rose-50' },
+                    { value: 'high',   label: '急ぎ', className: 'border-rose-200 text-rose-700 bg-rose-50' },
                   ] as const).map(opt => (
                     <button
                       key={opt.value}
@@ -612,7 +612,7 @@ function RequestFormContent() {
                       className={`flex-1 py-2 rounded-xl text-xs font-black border-2 transition-all ${
                         priority === opt.value
                           ? opt.className + ' ring-2 ring-offset-1 ring-current'
-                          : 'border-slate-100 text-slate-300 bg-white hover:border-slate-200'
+                          : 'border-slate-100 text-slate-500 bg-white hover:border-slate-200'
                       }`}
                     >
                       {opt.label}
@@ -622,7 +622,7 @@ function RequestFormContent() {
               </div>
 
               <div className="space-y-2" id="field-__title">
-                <label htmlFor="req-title" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">タイトル <span className="text-rose-500">*</span></label>
+                <label htmlFor="req-title" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">タイトル <span className="text-rose-600">*</span></label>
                 <input
                   id="req-title"
                   type="text"
@@ -633,10 +633,10 @@ function RequestFormContent() {
                   aria-invalid={!!fieldErrors['__title']}
                   aria-describedby={fieldErrors['__title'] ? 'err-__title' : undefined}
                 />
-                {fieldErrors['__title'] && <p id="err-__title" className="text-xs text-rose-500 font-bold px-1">{fieldErrors['__title']}</p>}
+                {fieldErrors['__title'] && <p id="err-__title" className="text-xs text-rose-600 font-bold px-1">{fieldErrors['__title']}</p>}
               </div>
               <div className="space-y-2" id="field-__description">
-                <label htmlFor="req-description" className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">詳細説明 / 追記</label>
+                <label htmlFor="req-description" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">詳細説明 / 追記</label>
                 <textarea
                   id="req-description"
                   rows={6}
@@ -647,7 +647,7 @@ function RequestFormContent() {
                   aria-invalid={!!fieldErrors['__description']}
                   aria-describedby={fieldErrors['__description'] ? 'err-__description' : undefined}
                 />
-                {fieldErrors['__description'] && <p id="err-__description" className="text-xs text-rose-500 font-bold px-1">{fieldErrors['__description']}</p>}
+                {fieldErrors['__description'] && <p id="err-__description" className="text-xs text-rose-600 font-bold px-1">{fieldErrors['__description']}</p>}
               </div>
 
               {/* Dynamic Fields Section */}
@@ -671,10 +671,10 @@ function RequestFormContent() {
                         <div key={field.id} className="space-y-2" id={`field-${field.id}`}>
                           <label
                             htmlFor={!['checkbox', 'file'].includes(field.type) ? `custom-field-${field.id}` : undefined}
-                            className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1"
+                            className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1"
                           >
                             {field.label}
-                            {field.required && <span className="text-rose-500 ml-1">*</span>}
+                            {field.required && <span className="text-rose-600 ml-1">*</span>}
                           </label>
 
                           {field.type === 'select' ? (
@@ -690,7 +690,7 @@ function RequestFormContent() {
                                 <option value="">選択してください</option>
                                 {field.options?.map(opt => <option key={opt} value={opt}>{opt}</option>)}
                               </select>
-                              <ChevronDown className="absolute right-3 top-3.5 w-5 h-5 text-slate-400 pointer-events-none" />
+                              <ChevronDown className="absolute right-3 top-3.5 w-5 h-5 text-slate-500 pointer-events-none" />
                             </div>
                           ) : field.type === 'textarea' ? (
                             <textarea
@@ -743,7 +743,7 @@ function RequestFormContent() {
                               aria-describedby={hasErr ? errId : undefined}
                             />
                           )}
-                          {hasErr && <p id={errId} className="text-xs text-rose-500 font-bold px-1">{fieldErrors[field.id]}</p>}
+                          {hasErr && <p id={errId} className="text-xs text-rose-600 font-bold px-1">{fieldErrors[field.id]}</p>}
                         </div>
                       );
                     })}
@@ -803,7 +803,7 @@ function RequestFormContent() {
                   e.preventDefault();
                   addFiles(Array.from(e.dataTransfer.files));
                 }}
-                className="flex items-center gap-2 p-4 mt-4 bg-slate-50 border border-dashed rounded-xl text-slate-400 cursor-pointer hover:bg-slate-100 hover:text-slate-600 transition-all"
+                className="flex items-center gap-2 p-4 mt-4 bg-slate-50 border border-dashed rounded-xl text-slate-500 cursor-pointer hover:bg-slate-100 hover:text-slate-600 transition-all"
               >
                 <Plus className="w-4 h-4 ml-auto" />
                 <span className="text-xs font-bold mr-auto">ファイルを添付またはドラッグ＆ドロップ</span>
@@ -822,16 +822,16 @@ function RequestFormContent() {
                 <div className="mt-2 space-y-1">
                   {attachedFiles.map((file, idx) => (
                     <div key={idx} className="flex items-center gap-2 px-3 py-2 bg-white border border-slate-200 rounded-xl text-xs font-bold text-slate-600">
-                      <FileText className="w-3.5 h-3.5 text-slate-400 shrink-0" />
+                      <FileText className="w-3.5 h-3.5 text-slate-500 shrink-0" />
                       <span className="flex-1 truncate">{file.name}</span>
-                      <span className="text-slate-300 shrink-0">{(file.size / 1024).toFixed(0)} KB</span>
+                      <span className="text-slate-500 shrink-0">{(file.size / 1024).toFixed(0)} KB</span>
                       <button
                         type="button"
                         onClick={(e) => {
                           e.stopPropagation();
                           setAttachedFiles(prev => prev.filter((_, i) => i !== idx));
                         }}
-                        className="text-slate-300 hover:text-rose-500 transition-colors"
+                        className="text-slate-500 hover:text-rose-600 transition-colors"
                         aria-label={`${file.name}を削除`}
                       >
                         <X className="w-3.5 h-3.5" />
@@ -843,9 +843,9 @@ function RequestFormContent() {
               {fileErrors.length > 0 && (
                 <div className="mt-2 space-y-1">
                   {fileErrors.map((err, idx) => (
-                    <p key={idx} className="text-xs text-rose-500 font-bold px-1">{err}</p>
+                    <p key={idx} className="text-xs text-rose-600 font-bold px-1">{err}</p>
                   ))}
-                  <p className="text-[10px] text-slate-400 px-1">
+                  <p className="text-[10px] text-slate-500 px-1">
                     許可形式: {ALLOWED_EXTENSIONS.join(', ')} ／ 上限: 10MB
                   </p>
                 </div>
@@ -858,7 +858,7 @@ function RequestFormContent() {
         <aside className="space-y-6">
           <div className="sticky top-24 space-y-8">
             <div className="flex items-center justify-between px-2">
-              <div className="flex items-center gap-2 text-xs font-bold text-slate-400 uppercase tracking-widest">
+              <div className="flex items-center gap-2 text-xs font-bold text-slate-500 uppercase tracking-widest">
                 <span className="w-5 h-5 rounded bg-slate-100 flex items-center justify-center text-slate-900 border">3</span>
                 承認フロー
               </div>
@@ -878,7 +878,7 @@ function RequestFormContent() {
             {/* Cc Users compact section */}
             <div className="space-y-4 px-2">
               <div className="flex items-center justify-between">
-                <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">CC（共有先）</div>
+                <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">CC（共有先）</div>
                 <button 
                   type="button"
                   onClick={() => {
@@ -901,14 +901,14 @@ function RequestFormContent() {
                     <button 
                       type="button"
                       onClick={() => removeCcUser(idx)}
-                      className="text-slate-300 hover:text-rose-500 transition-colors"
+                      className="text-slate-500 hover:text-rose-600 transition-colors"
                     >
                       <X className="w-2.5 h-2.5" />
                     </button>
                   </div>
                 ))}
                 {ccRoute.length === 0 && (
-                  <div className="text-[10px] text-slate-300 italic font-medium">指定なし</div>
+                  <div className="text-[10px] text-slate-500 italic font-medium">指定なし</div>
                 )}
               </div>
             </div>
@@ -930,7 +930,7 @@ function RequestFormContent() {
                             ? 'bg-violet-50 border-violet-200 text-violet-600'
                             : step.parallelType === 'or'
                             ? 'bg-amber-50 border-amber-200 text-amber-600'
-                            : 'bg-slate-50 border-slate-200 text-slate-300 hover:border-slate-400 hover:text-slate-500'
+                            : 'bg-slate-50 border-slate-200 text-slate-500 hover:border-slate-400 hover:text-slate-500'
                         }`}
                         title="クリックして並列設定を変更: なし → AND（全員承認）→ OR（1名でOK）"
                       >
@@ -943,7 +943,7 @@ function RequestFormContent() {
                         : <div className="w-8 h-8 rounded-lg bg-slate-100" />
                       }
                       <div className="flex-1 min-w-0">
-                        <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest truncate">{step.position}</div>
+                        <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest truncate">{step.position}</div>
                         <div className="text-xs font-bold text-[#191714] truncate">{step.userName}</div>
                       </div>
                       <button
@@ -995,12 +995,12 @@ function RequestFormContent() {
             <div className="p-6 border-b flex items-center justify-between">
               <h3 id="draft-list-modal-title" className="text-lg font-bold text-[#191714]">保存済み下書き</h3>
               <button type="button" onClick={() => setShowDraftList(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
-                <X className="w-5 h-5 text-slate-400" />
+                <X className="w-5 h-5 text-slate-500" />
               </button>
             </div>
             <div className="max-h-96 overflow-y-auto p-3 space-y-2">
               {drafts.length === 0 && (
-                <p className="text-center text-sm text-slate-400 py-8">下書きはありません</p>
+                <p className="text-center text-sm text-slate-500 py-8">下書きはありません</p>
               )}
               {drafts.map((draft) => {
                 const savedAt = new Date(draft.savedAt);
@@ -1009,10 +1009,10 @@ function RequestFormContent() {
                   : savedAt.toLocaleDateString('ja-JP') + ' ' + savedAt.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
                 return (
                   <div key={draft.id} className="flex items-center gap-3 p-3 bg-slate-50 border border-slate-200 rounded-2xl group hover:border-slate-400 transition-all">
-                    <FileText className="w-5 h-5 text-slate-400 shrink-0" />
+                    <FileText className="w-5 h-5 text-slate-500 shrink-0" />
                     <div className="flex-1 min-w-0">
                       <div className="text-sm font-bold text-[#191714] truncate">{draft.title}</div>
-                      <div className="text-[10px] text-slate-400 font-medium">{dateLabel}</div>
+                      <div className="text-[10px] text-slate-500 font-medium">{dateLabel}</div>
                     </div>
                     <button
                       type="button"
@@ -1024,7 +1024,7 @@ function RequestFormContent() {
                     <button
                       type="button"
                       onClick={() => handleDeleteDraft(draft.id)}
-                      className="p-1 text-slate-300 hover:text-rose-500 transition-colors shrink-0"
+                      className="p-1 text-slate-500 hover:text-rose-600 transition-colors shrink-0"
                       aria-label="削除"
                     >
                       <Trash2 className="w-4 h-4" />
@@ -1054,11 +1054,11 @@ function RequestFormContent() {
                   {searchMode === 'approver' ? '承認者の検索・追加' : 'CC（共有先）の検索・追加'}
                 </h3>
                 <button type="button" onClick={() => setShowSearch(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
-                  <X className="w-5 h-5 text-slate-400" />
+                  <X className="w-5 h-5 text-slate-500" />
                 </button>
               </div>
               <div className="relative">
-                <Search className="absolute left-4 top-3.5 w-5 h-5 text-slate-300" />
+                <Search className="absolute left-4 top-3.5 w-5 h-5 text-slate-500" />
                 <input
                   type="text"
                   autoFocus
@@ -1083,10 +1083,10 @@ function RequestFormContent() {
                       : <div className="w-10 h-10 rounded-xl bg-slate-100" />
                     }
                     <div className="flex-1">
-                      <div className="text-xs font-bold text-slate-400 uppercase tracking-widest">{u.position}</div>
+                      <div className="text-xs font-bold text-slate-500 uppercase tracking-widest">{u.position}</div>
                       <div className="text-sm font-bold text-[#191714]">{u.name}</div>
                     </div>
-                    <Plus className="w-5 h-5 text-slate-300 opacity-0 group-hover:opacity-100 transition-all" />
+                    <Plus className="w-5 h-5 text-slate-500 opacity-0 group-hover:opacity-100 transition-all" />
                   </button>
                 ))}
               </div>
@@ -1100,7 +1100,7 @@ function RequestFormContent() {
 
 export default function RequestForm() {
   return (
-    <Suspense fallback={<div className="p-8 text-slate-400 text-sm font-medium">フォームを読み込み中...</div>}>
+    <Suspense fallback={<div className="p-8 text-slate-500 text-sm font-medium">フォームを読み込み中...</div>}>
       <RequestFormContent />
     </Suspense>
   );

--- a/src/app/tracker/page.tsx
+++ b/src/app/tracker/page.tsx
@@ -26,8 +26,8 @@ import { useRouter } from 'next/navigation';
 import { ClientOnlyDate } from '@/components/common/client-only-date';
 
 const PRIORITY_MAP = {
-  high:   { label: '急ぎ',  className: 'bg-rose-50 text-rose-600 border-rose-100' },
-  normal: { label: '通常',  className: 'bg-slate-50 text-slate-400 border-slate-100' },
+  high:   { label: '急ぎ',  className: 'bg-rose-50 text-rose-700 border-rose-100' },
+  normal: { label: '通常',  className: 'bg-slate-50 text-slate-500 border-slate-100' },
   low:    { label: '低',    className: 'bg-sky-50 text-sky-400 border-sky-100' },
 };
 
@@ -150,7 +150,7 @@ export default function ProgressTracker() {
         {/* B-2: 検索・フィルターバー */}
         <div className="flex flex-col sm:flex-row gap-3">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-2.5 w-4 h-4 text-slate-300" />
+            <Search className="absolute left-3 top-2.5 w-4 h-4 text-slate-500" />
             <input
               type="text"
               placeholder="タイトル・カテゴリーで検索..."
@@ -174,7 +174,7 @@ export default function ProgressTracker() {
                   "px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-widest border transition-all whitespace-nowrap",
                   statusFilter === f.value
                     ? "bg-slate-900 text-white border-slate-900"
-                    : "bg-white text-slate-400 border-slate-200 hover:border-slate-400"
+                    : "bg-white text-slate-500 border-slate-200 hover:border-slate-400"
                 )}
               >
                 {f.label}
@@ -187,17 +187,17 @@ export default function ProgressTracker() {
       {/* Task Table */}
       <div className="bg-white rounded-2xl border border-slate-200 notion-shadow overflow-hidden">
         {filteredTasks.length === 0 ? (
-          <div className="py-16 text-center text-slate-300 text-sm font-bold uppercase tracking-widest">
+          <div className="py-16 text-center text-slate-500 text-sm font-bold uppercase tracking-widest">
             該当する申請がありません
           </div>
         ) : (
           <table className="w-full text-left">
             <thead>
               <tr className="bg-slate-50/50 border-b">
-                <th className="px-4 py-3 text-[10px] font-black text-slate-400 uppercase tracking-widest">ステータス</th>
-                <th className="px-4 py-3 text-[10px] font-black text-slate-400 uppercase tracking-widest">タイトル / カテゴリー</th>
-                <th className="px-4 py-3 text-[10px] font-black text-slate-400 uppercase tracking-widest">承認進捗</th>
-                <th className="px-4 py-3 text-[10px] font-black text-slate-400 uppercase tracking-widest text-right">期限</th>
+                <th className="px-4 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">ステータス</th>
+                <th className="px-4 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">タイトル / カテゴリー</th>
+                <th className="px-4 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">承認進捗</th>
+                <th className="px-4 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest text-right">期限</th>
                 <th className="w-8"></th>
               </tr>
             </thead>
@@ -220,7 +220,7 @@ export default function ProgressTracker() {
                           "px-2 py-0.5 rounded-full text-[9px] font-black uppercase tracking-tight border",
                           task.status === 'completed' ? "bg-emerald-50 text-emerald-600 border-emerald-100" :
                           task.status === 'in_progress' ? "bg-blue-50 text-blue-600 border-blue-100" :
-                          "bg-slate-50 text-slate-400 border-slate-100"
+                          "bg-slate-50 text-slate-500 border-slate-100"
                         )}>
                           {getStatusLabel(task.status)}
                         </span>
@@ -240,7 +240,7 @@ export default function ProgressTracker() {
                     </td>
                     <td className="px-4 py-3 max-w-xs">
                       <div className="text-sm font-bold text-[#191714] group-hover:text-blue-600 transition-colors line-clamp-1">{task.title}</div>
-                      <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-0.5">{task.category}</div>
+                      <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mt-0.5">{task.category}</div>
                     </td>
                     <td className="px-4 py-3 w-40">
                       {totalSteps > 0 ? (
@@ -259,16 +259,16 @@ export default function ProgressTracker() {
                               />
                             ))}
                           </div>
-                          <div className="text-[9px] font-black text-slate-400">{approvedCount}/{totalSteps} ステップ</div>
+                          <div className="text-[9px] font-black text-slate-500">{approvedCount}/{totalSteps} ステップ</div>
                         </div>
                       ) : (
-                        <span className="text-[10px] text-slate-300">—</span>
+                        <span className="text-[10px] text-slate-500">—</span>
                       )}
                     </td>
                     <td className="px-4 py-3 text-right">
                       <span className={cn(
                         "text-[10px] font-bold",
-                        isOverdue ? "text-rose-500" : "text-slate-400"
+                        isOverdue ? "text-rose-700" : "text-slate-500"
                       )}>
                         <ClientOnlyDate date={task.dueDate} />
                       </span>
@@ -293,7 +293,7 @@ export default function ProgressTracker() {
               <div className="flex items-center gap-4">
                 <div className="w-10 h-10 rounded-xl bg-slate-900 text-white flex items-center justify-center font-bold">TB</div>
                 <div>
-                  <div className="text-[10px] font-black text-slate-400 uppercase tracking-widest leading-none">Task Trace</div>
+                  <div className="text-[10px] font-black text-slate-500 uppercase tracking-widest leading-none">Task Trace</div>
                   <div className="text-sm font-bold text-[#191714]">進捗トラッカー</div>
                 </div>
               </div>
@@ -308,7 +308,7 @@ export default function ProgressTracker() {
                 </button>
                 <button
                   onClick={() => setSelectedTask(null)}
-                  className="p-2 hover:bg-slate-100 rounded-xl transition-colors text-slate-400 hover:text-slate-900"
+                  className="p-2 hover:bg-slate-100 rounded-xl transition-colors text-slate-500 hover:text-slate-900"
                 >
                   <X className="w-6 h-6" />
                 </button>
@@ -329,7 +329,7 @@ export default function ProgressTracker() {
                       </span>
                     );
                   })()}
-                  <span className="text-[10px] font-bold text-slate-300">ID: {selectedTask.id}</span>
+                  <span className="text-[10px] font-bold text-slate-500">ID: {selectedTask.id}</span>
                 </div>
                 <h1 className="text-xl font-black tracking-tight text-[#191714] leading-tight">
                   {selectedTask.title}
@@ -338,7 +338,7 @@ export default function ProgressTracker() {
                 {/* A-3: 承認進捗ステッパー（詳細） */}
                 {selectedTask.approvalRoute.length > 0 && (
                   <div className="bg-slate-50 rounded-2xl p-4 border border-slate-100">
-                    <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-3">承認進捗</div>
+                    <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-3">承認進捗</div>
                     <div className="flex items-center gap-0">
                       {selectedTask.approvalRoute.map((step, idx) => (
                         <div key={idx} className="flex items-center flex-1 min-w-0">
@@ -359,7 +359,7 @@ export default function ProgressTracker() {
                                 : <div className="w-2 h-2 bg-slate-200 rounded-full" />
                               }
                             </div>
-                            <span className="text-[8px] font-bold text-slate-400 truncate w-full text-center px-1">{step.userName.split(' ')[0]}</span>
+                            <span className="text-[8px] font-bold text-slate-500 truncate w-full text-center px-1">{step.userName.split(' ')[0]}</span>
                           </div>
                           {idx < selectedTask.approvalRoute.length - 1 && (
                             <div className={cn(
@@ -375,16 +375,16 @@ export default function ProgressTracker() {
 
                 <div className="flex items-center gap-6 py-3 border-y border-slate-100">
                   <div className="space-y-1">
-                    <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">現在のステータス</div>
+                    <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">現在のステータス</div>
                     <div className="flex items-center gap-2">
                       <div className="w-2 h-2 rounded-full bg-blue-500" />
                       <span className="text-sm font-black text-blue-600 uppercase tracking-widest">{getStatusLabel(selectedTask.status)}</span>
                     </div>
                   </div>
                   <div className="space-y-1">
-                    <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">目標完了日 (SLA)</div>
+                    <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">目標完了日 (SLA)</div>
                     <div className="flex items-center gap-2">
-                      <Calendar className="w-4 h-4 text-slate-300" />
+                      <Calendar className="w-4 h-4 text-slate-500" />
                       <span className="text-sm font-bold text-[#191714]"><ClientOnlyDate date={selectedTask.dueDate} /></span>
                     </div>
                   </div>
@@ -392,12 +392,12 @@ export default function ProgressTracker() {
               </header>
 
               <section className="space-y-4">
-                <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+                <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
                   <FileText className="w-4 h-4" />
                   申請内容の要約
                 </h3>
                 <div className="text-sm font-medium text-slate-600 leading-relaxed bg-slate-50/50 p-4 rounded-xl border border-slate-100">
-                  {selectedTask.description || <span className="text-slate-400 italic">追加の説明はありません。</span>}
+                  {selectedTask.description || <span className="text-slate-500 italic">追加の説明はありません。</span>}
                 </div>
 
                 {selectedTask.customData && Object.keys(selectedTask.customData).length > 0 && (
@@ -406,7 +406,7 @@ export default function ProgressTracker() {
                     <div className="grid grid-cols-2 gap-y-4">
                       {Object.entries(selectedTask.customData).map(([key, value]) => (
                         <div key={key} className="space-y-1">
-                          <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{key}</div>
+                          <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">{key}</div>
                           <div className="text-sm font-bold text-[#191714]">{value as string}</div>
                         </div>
                       ))}
@@ -417,7 +417,7 @@ export default function ProgressTracker() {
 
               {/* Approval Route Visual */}
               <section className="space-y-3">
-                <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+                <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
                   <ShieldCheck className="w-4 h-4" />
                   承認の軌跡
                 </h3>
@@ -437,10 +437,10 @@ export default function ProgressTracker() {
                       <div className="flex items-center gap-4">
                         {step.avatar
                           ? <Image src={step.avatar} width={40} height={40} className="w-10 h-10 rounded-xl bg-slate-100" alt="" />
-                          : <div className="w-10 h-10 rounded-xl bg-slate-100 flex items-center justify-center text-xs font-bold text-slate-400">U</div>
+                          : <div className="w-10 h-10 rounded-xl bg-slate-100 flex items-center justify-center text-xs font-bold text-slate-500">U</div>
                         }
                         <div>
-                          <div className="text-[9px] font-bold text-slate-400 uppercase tracking-widest leading-none mb-1">{step.position || '役職なし'}</div>
+                          <div className="text-[9px] font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">{step.position || '役職なし'}</div>
                           <div className="text-sm font-bold text-[#191714]">{step.userName}</div>
                         </div>
                       </div>
@@ -450,14 +450,14 @@ export default function ProgressTracker() {
                           step.status === 'approved' ? "bg-emerald-50 text-emerald-600 border-emerald-100" :
                           step.status === 'rejected' ? "bg-rose-50 text-rose-600 border-rose-100" :
                           selectedTask.currentApproverId === step.userId ? "bg-blue-50 text-blue-600 border-blue-100" :
-                          "bg-slate-50 text-slate-300 border-slate-100"
+                          "bg-slate-50 text-slate-500 border-slate-100"
                         )}>
                           {step.status === 'approved' ? '承認済' :
                            step.status === 'rejected' ? '差し戻し' :
                            selectedTask.currentApproverId === step.userId ? '対応中' : '審査待ち'}
                         </span>
                         {step.processedAt && (
-                          <div className="text-[8px] font-bold text-slate-400">
+                          <div className="text-[8px] font-bold text-slate-500">
                             <ClientOnlyDate date={step.processedAt} showTime />
                           </div>
                         )}
@@ -469,7 +469,7 @@ export default function ProgressTracker() {
 
               {/* Log History */}
               <section className="space-y-6">
-                <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+                <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
                   <History className="w-4 h-4" />
                   アクション履歴
                 </h3>
@@ -478,7 +478,7 @@ export default function ProgressTracker() {
                     <div key={log.id} className="relative">
                       <div className="absolute -left-[31px] top-1 w-2 h-2 rounded-full bg-slate-200 ring-4 ring-white" />
                       <div className="space-y-1">
-                        <div className="text-[10px] font-bold text-slate-400"><ClientOnlyDate date={log.timestamp} showTime /></div>
+                        <div className="text-[10px] font-bold text-slate-500"><ClientOnlyDate date={log.timestamp} showTime /></div>
                         <div className="flex items-center gap-2 flex-wrap">
                           <span className="text-xs font-bold text-[#191714]">{log.userName}</span>
                           <span className="text-xs font-medium text-slate-500">が</span>
@@ -503,7 +503,7 @@ export default function ProgressTracker() {
 
               {/* In-App Messaging (Comments) */}
               <section className="space-y-6 pt-4 border-t">
-                <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+                <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
                   <MessageSquare className="w-4 h-4" />
                   連絡・コメントを追加
                 </h3>
@@ -543,7 +543,7 @@ export default function ProgressTracker() {
                     <XCircle className="w-4 h-4" />
                     {isCancelling ? 'キャンセル中...' : 'この申請をキャンセルする'}
                   </button>
-                  <p className="text-center text-[10px] text-slate-300 mt-2 font-medium">承認者がまだ処理していない場合のみキャンセルできます</p>
+                  <p className="text-center text-[10px] text-slate-500 mt-2 font-medium">承認者がまだ処理していない場合のみキャンセルできます</p>
                 </section>
               )}
 
@@ -560,7 +560,7 @@ export default function ProgressTracker() {
                     <RotateCcw className="w-4 h-4" />
                     修正して再申請する
                   </button>
-                  <p className="text-center text-[10px] text-slate-300 mt-2 font-medium">内容を修正し、同じ申請として再送信できます</p>
+                  <p className="text-center text-[10px] text-slate-500 mt-2 font-medium">内容を修正し、同じ申請として再送信できます</p>
                 </section>
               )}
             </div>

--- a/src/components/layout/app-content.tsx
+++ b/src/components/layout/app-content.tsx
@@ -25,7 +25,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
       <div className="flex items-center justify-center min-h-screen bg-slate-50">
         <div className="flex flex-col items-center gap-4">
           <div className="w-12 h-12 border-4 border-slate-200 border-t-slate-800 rounded-full animate-spin" />
-          <p className="text-sm font-bold text-slate-400 animate-pulse">LOADING TASK BRIDGE...</p>
+          <p className="text-sm font-bold text-slate-500 animate-pulse">LOADING TASK BRIDGE...</p>
         </div>
       </div>
     );

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -70,13 +70,13 @@ export function Header() {
           >
             <Menu className="w-4 h-4" />
           </button>
-          <span className="hidden sm:inline text-slate-300">Task Flow</span>
+          <span className="hidden sm:inline text-slate-500">Task Flow</span>
           <ChevronRight className="hidden sm:block w-3 h-3 text-slate-200" />
           <span className="text-[#191714] bg-slate-50 px-2 py-1 rounded border shadow-sm">{getBreadcrumb()}</span>
         </div>
 
         <div className="flex items-center gap-5">
-          <div className="hidden md:flex items-center gap-1.5 px-3 py-1.5 bg-slate-50 border rounded-lg text-slate-400 group hover:border-slate-300 transition-all cursor-pointer">
+          <div className="hidden md:flex items-center gap-1.5 px-3 py-1.5 bg-slate-50 border rounded-lg text-slate-500 group hover:border-slate-300 transition-all cursor-pointer">
             <Search className="w-3.5 h-3.5" />
             <span className="text-[10px] font-bold uppercase tracking-widest">検索...</span>
             <span className="ml-8 text-[10px] bg-white border px-1 rounded shadow-sm">⌘K</span>
@@ -102,10 +102,10 @@ export function Header() {
                   <div className="px-4 py-3 border-b flex items-center justify-between">
                     <span className="text-xs font-black text-[#191714] uppercase tracking-widest">通知</span>
                     <button onClick={() => setShowNotifPanel(false)} className="p-1 hover:bg-slate-100 rounded-lg transition-colors" aria-label="通知パネルを閉じる">
-                      <X className="w-3.5 h-3.5 text-slate-400" />
+                      <X className="w-3.5 h-3.5 text-slate-500" />
                     </button>
                   </div>
-                  <div className="py-10 flex flex-col items-center gap-2 text-slate-400">
+                  <div className="py-10 flex flex-col items-center gap-2 text-slate-500">
                     <Bell className="w-8 h-8 text-slate-200" />
                     <p className="text-xs font-bold">新着通知はありません</p>
                   </div>
@@ -130,14 +130,14 @@ export function Header() {
           >
             <div className="text-right flex flex-col justify-center cursor-pointer">
               <div className="text-xs font-bold text-[#191714]">{user?.name || '読み込み中...'}</div>
-              <div className="text-[9px] font-bold text-slate-400 uppercase tracking-widest leading-tight">{getRoleLabel(user?.position)}</div>
+              <div className="text-[9px] font-bold text-slate-500 uppercase tracking-widest leading-tight">{getRoleLabel(user?.position)}</div>
             </div>
             <div className="w-8 h-8 rounded-full bg-slate-100 border overflow-hidden p-0.5 ring-2 ring-transparent hover:ring-slate-100 transition-all cursor-pointer">
               {user?.avatar ? (
                 <Image src={user.avatar} width={32} height={32} alt={user.name} className="w-full h-full object-cover rounded-full" />
               ) : (
                 <div className="w-full h-full bg-slate-200 flex items-center justify-center rounded-full">
-                  <User className="w-4 h-4 text-slate-400" />
+                  <User className="w-4 h-4 text-slate-500" />
                 </div>
               )}
             </div>
@@ -154,20 +154,20 @@ export function Header() {
               <div className="absolute -top-2 left-0 w-full h-2 bg-transparent" />
 
               <div className="px-3 py-2 border-b mb-1">
-                <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">アカウント</p>
+                <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">アカウント</p>
               </div>
               <button
                 onClick={() => { setIsMenuOpen(false); router.push('/organization'); }}
                 className="w-full flex items-center gap-2 px-3 py-2 text-xs font-bold text-slate-600 hover:bg-slate-50 rounded-lg transition-colors"
               >
-                <User className="w-3.5 h-3.5 text-slate-400" />
+                <User className="w-3.5 h-3.5 text-slate-500" />
                 プロフィール設定
               </button>
               <button
                 onClick={() => { setIsMenuOpen(false); router.push('/admin'); }}
                 className="w-full flex items-center gap-2 px-3 py-2 text-xs font-bold text-slate-600 hover:bg-slate-50 rounded-lg transition-colors"
               >
-                <Settings className="w-3.5 h-3.5 text-slate-400" />
+                <Settings className="w-3.5 h-3.5 text-slate-500" />
                 環境設定
               </button>
               <div className="my-1 border-t" />
@@ -202,7 +202,7 @@ export function Header() {
                 <h3 id="help-modal-title" className="text-lg font-bold text-[#191714]">ヘルプ・よくある質問</h3>
               </div>
               <button type="button" onClick={() => setShowHelpModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
-                <X className="w-5 h-5 text-slate-400" />
+                <X className="w-5 h-5 text-slate-500" />
               </button>
             </div>
             <div className="p-6 space-y-4">
@@ -221,7 +221,7 @@ export function Header() {
                   </div>
                 </div>
               ))}
-              <p className="text-center text-[10px] text-slate-400 font-medium pt-2">
+              <p className="text-center text-[10px] text-slate-500 font-medium pt-2">
                 詳細なサポートはサイドバーの「サポート・ヘルプ」からご連絡ください。
               </p>
             </div>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -71,7 +71,7 @@ export function Sidebar() {
           {/* モバイルのみ表示: 閉じるボタン */}
           <button
             onClick={close}
-            className="md:hidden p-1.5 hover:bg-slate-100 rounded-lg transition-colors text-slate-400"
+            className="md:hidden p-1.5 hover:bg-slate-100 rounded-lg transition-colors text-slate-500"
             aria-label="メニューを閉じる"
           >
             <X className="w-4 h-4" />
@@ -80,7 +80,7 @@ export function Sidebar() {
 
         {/* Main Nav */}
         <nav className="flex-1 px-3 py-6 space-y-0.5">
-          <div className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-3 mb-2">メニュー</div>
+          <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-3 mb-2">メニュー</div>
           {filteredNav.map((item) => {
             const isActive = pathname === item.href;
             return (
@@ -92,40 +92,40 @@ export function Sidebar() {
                   "flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-bold transition-all group",
                   isActive
                     ? "bg-white text-[#191714] notion-shadow border border-slate-200"
-                    : "text-slate-400 hover:text-slate-600 hover:bg-slate-100/50"
+                    : "text-slate-500 hover:text-slate-600 hover:bg-slate-100/50"
                 )}
               >
                 <item.icon className={cn(
                   "w-4 h-4 transition-colors",
-                  isActive ? "text-[#191714]" : "text-slate-300 group-hover:text-slate-500"
+                  isActive ? "text-[#191714]" : "text-slate-500 group-hover:text-slate-500"
                 )} />
                 {item.name}
-                {isActive && <ChevronRight className="w-3 h-3 ml-auto text-slate-300" />}
+                {isActive && <ChevronRight className="w-3 h-3 ml-auto text-slate-500" />}
               </Link>
             );
           })}
 
-          <div className="pt-8 text-[10px] font-bold text-slate-400 uppercase tracking-widest px-3 mb-2">ワークスペース</div>
+          <div className="pt-8 text-[10px] font-bold text-slate-500 uppercase tracking-widest px-3 mb-2">ワークスペース</div>
           <Link
             href="/organization"
             className={cn(
               "w-full flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-bold transition-all group",
               pathname === '/organization'
                 ? "bg-white text-[#191714] notion-shadow border border-slate-200"
-                : "text-slate-400 hover:text-slate-600 hover:bg-slate-100/50"
+                : "text-slate-500 hover:text-slate-600 hover:bg-slate-100/50"
             )}
           >
             <Building2 className={cn(
               "w-4 h-4 transition-colors",
-              pathname === '/organization' ? "text-[#191714]" : "text-slate-300 group-hover:text-slate-500"
+              pathname === '/organization' ? "text-[#191714]" : "text-slate-500 group-hover:text-slate-500"
             )} />
             組織図
           </Link>
           <button
             onClick={() => setShowRulesModal(true)}
-            className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-bold text-slate-400 hover:text-slate-600 hover:bg-slate-100/50 transition-all group"
+            className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-bold text-slate-500 hover:text-slate-600 hover:bg-slate-100/50 transition-all group"
           >
-            <ShieldCheck className="w-4 h-4 text-slate-300 group-hover:text-slate-500" />
+            <ShieldCheck className="w-4 h-4 text-slate-500 group-hover:text-slate-500" />
             社内規定・規約
           </button>
         </nav>
@@ -134,16 +134,16 @@ export function Sidebar() {
         <div className="p-3 mt-auto space-y-0.5 border-t border-slate-100/10">
           <button
             onClick={() => setShowHelpModal(true)}
-            className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-bold text-slate-400 hover:text-slate-600 hover:bg-slate-100/50 transition-all group"
+            className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-bold text-slate-500 hover:text-slate-600 hover:bg-slate-100/50 transition-all group"
           >
-            <HelpCircle className="w-4 h-4 text-slate-300 group-hover:text-slate-500" />
+            <HelpCircle className="w-4 h-4 text-slate-500 group-hover:text-slate-500" />
             サポート・ヘルプ
           </button>
           <button
             onClick={logout}
-            className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-bold text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-all group"
+            className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-bold text-slate-500 hover:text-rose-600 hover:bg-rose-50 transition-all group"
           >
-            <LogOut className="w-4 h-4 text-slate-300 group-hover:text-rose-500" />
+            <LogOut className="w-4 h-4 text-slate-500 group-hover:text-rose-500" />
             ログアウト
           </button>
         </div>
@@ -162,7 +162,7 @@ export function Sidebar() {
                 <h3 id="rules-modal-title" className="text-lg font-bold text-[#191714]">社内規定・規約</h3>
               </div>
               <button onClick={() => setShowRulesModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="モーダルを閉じる">
-                <X className="w-5 h-5 text-slate-400" />
+                <X className="w-5 h-5 text-slate-500" />
               </button>
             </div>
             <div className="p-6 space-y-3">
@@ -173,14 +173,14 @@ export function Sidebar() {
                 { label: '個人情報保護方針', desc: 'プライバシーポリシー' },
               ].map(item => (
                 <div key={item.label} className="flex items-center gap-3 p-3 bg-slate-50 rounded-2xl border border-slate-100">
-                  <FileText className="w-4 h-4 text-slate-400 shrink-0" />
+                  <FileText className="w-4 h-4 text-slate-500 shrink-0" />
                   <div className="flex-1">
                     <div className="text-sm font-bold text-[#191714]">{item.label}</div>
-                    <div className="text-[10px] text-slate-400 font-medium">{item.desc}</div>
+                    <div className="text-[10px] text-slate-500 font-medium">{item.desc}</div>
                   </div>
                 </div>
               ))}
-              <p className="text-center text-[10px] text-slate-400 font-medium pt-2">
+              <p className="text-center text-[10px] text-slate-500 font-medium pt-2">
                 詳細は人事部ポータルをご確認ください（準備中）
               </p>
             </div>
@@ -201,7 +201,7 @@ export function Sidebar() {
                 <h3 id="help-modal-title" className="text-lg font-bold text-[#191714]">サポート・ヘルプ</h3>
               </div>
               <button onClick={() => setShowHelpModal(false)} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="モーダルを閉じる">
-                <X className="w-5 h-5 text-slate-400" />
+                <X className="w-5 h-5 text-slate-500" />
               </button>
             </div>
             <div className="p-6 space-y-4">
@@ -210,13 +210,13 @@ export function Sidebar() {
               </p>
               <div className="p-4 bg-slate-50 rounded-2xl border border-slate-100 space-y-2">
                 <div className="flex items-center gap-2 text-sm font-bold text-[#191714]">
-                  <Mail className="w-4 h-4 text-slate-400" />
+                  <Mail className="w-4 h-4 text-slate-500" />
                   システム管理部
                 </div>
                 <p className="text-xs text-slate-500 pl-6">helpdesk@digitalfoln.co.jp</p>
                 <p className="text-xs text-slate-500 pl-6">受付時間: 平日 9:00 〜 18:00</p>
               </div>
-              <p className="text-center text-[10px] text-slate-400 font-medium">
+              <p className="text-center text-[10px] text-slate-500 font-medium">
                 緊急の場合は内線 #5000 へお電話ください
               </p>
             </div>

--- a/src/components/organization/org-node.tsx
+++ b/src/components/organization/org-node.tsx
@@ -58,7 +58,7 @@ export function OrgNode({
         className="flex items-center gap-2 group cursor-pointer py-1.5"
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <div className="w-5 h-5 flex items-center justify-center text-slate-400 group-hover:text-slate-600">
+        <div className="w-5 h-5 flex items-center justify-center text-slate-500 group-hover:text-slate-600">
           {childUnits.length > 0 || directUsers.length > 0 ? (
             isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />
           ) : (
@@ -67,7 +67,7 @@ export function OrgNode({
         </div>
         <Building2 className={cn(
           "w-4 h-4 transition-colors",
-          isExpanded ? "text-slate-900" : "text-slate-400 group-hover:text-slate-600"
+          isExpanded ? "text-slate-900" : "text-slate-500 group-hover:text-slate-600"
         )} />
         <span className={cn(
           "text-sm font-bold transition-colors",
@@ -128,7 +128,7 @@ export function OrgNode({
                     {user.avatar ? (
                       <Image src={user.avatar} width={32} height={32} alt={user.name} className="w-full h-full rounded" />
                     ) : (
-                      <UserIcon className="w-4 h-4 text-slate-400" />
+                      <UserIcon className="w-4 h-4 text-slate-500" />
                     )}
                   </div>
                   {/* 管理者バッジ（Shieldアイコン） */}
@@ -143,10 +143,10 @@ export function OrgNode({
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-bold text-slate-800 truncate">{user.name}</span>
                     {mode === 'directory' && user.role === 'admin' && (
-                      <span className="text-[8px] font-black uppercase text-slate-400 bg-slate-50 px-1.5 py-0.5 rounded border border-slate-100">Admin</span>
+                      <span className="text-[8px] font-black uppercase text-slate-500 bg-slate-50 px-1.5 py-0.5 rounded border border-slate-100">Admin</span>
                     )}
                   </div>
-                  <span className="text-[9px] font-bold text-slate-400 uppercase tracking-widest leading-none truncate">{user.position}</span>
+                  <span className="text-[9px] font-bold text-slate-500 uppercase tracking-widest leading-none truncate">{user.position}</span>
                 </div>
 
                 {/* 右側のインジケータ（モード別） */}
@@ -158,7 +158,7 @@ export function OrgNode({
                     {count} 件
                   </span>
                 ) : (
-                  <ChevronRight className="ml-auto w-3 h-3 text-slate-200 group-hover:text-slate-400 transition-all opacity-0 group-hover:opacity-100 group-hover:translate-x-1" />
+                  <ChevronRight className="ml-auto w-3 h-3 text-slate-200 group-hover:text-slate-500 transition-all opacity-0 group-hover:opacity-100 group-hover:translate-x-1" />
                 )}
               </div>
             );


### PR DESCRIPTION
## Summary

- `text-slate-400` → `text-slate-500` に全ページ一括置換（白背景でのコントラスト比 2.97:1 → 約4.5:1 に改善）
- 情報を持つ `text-slate-300` テキスト（ID・空状態・説明文等）を `text-slate-500` に修正
- 低コントラストバッジ修正: `bg-rose-*/amber-*` 背景上の `-500`/`-600` テキストを `-700` に引き上げ
- SLA超過・overdue 日付テキスト `text-rose-500` → `text-rose-700`（7.6:1）
- ログインフォームのプレースホルダー `placeholder-slate-400` → `placeholder-slate-500`
- 装飾的要素（`~` 日付セパレーター、`aria-hidden` アイコン）は維持

Closes #35

## Test plan

- [ ] 全ページで `text-slate-500` が適切なコントラストで表示されること（白背景で約4.5:1）
- [ ] ステータスバッジ（overdue/高優先度）の文字色が視認できること
- [ ] ログインフォームのプレースホルダーが読めること
- [ ] `npm run typecheck` `npm run lint` が通ること