### PR TITLE
feat(perf): next/dynamic によるページ単位 Code Splitting 導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.104.1",
         "clsx": "^2.1.1",
+        "lightningcss": "^1.32.0",
         "lucide-react": "^1.7.0",
         "next": "^16.2.4",
         "react": "19.2.4",
@@ -4644,7 +4645,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6651,7 +6651,6 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -6684,7 +6683,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6705,7 +6703,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6726,7 +6723,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6747,7 +6743,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6768,7 +6763,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6789,7 +6783,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6810,7 +6803,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6831,7 +6823,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6852,7 +6843,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6873,7 +6863,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6894,7 +6883,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.104.1",
     "clsx": "^2.1.1",
+    "lightningcss": "^1.32.0",
     "lucide-react": "^1.7.0",
     "next": "^16.2.4",
     "react": "19.2.4",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, useMemo, startTransition } from 'react';
+import dynamic from 'next/dynamic';
 import { 
   ChevronRight,
   Plus,
@@ -24,13 +25,24 @@ import {
 } from 'lucide-react';
 import { getDataProvider } from '@/lib/repository/factory';
 import { mockProvider } from '@/lib/repository/mock-provider';
-import { Category, OrganizationUnit, User, AuditLog, Task, Delegation, AmountRule, CustomField, WorkflowStepTemplate, ApproverType } from '@/lib/repository/types';
+import { Category, OrganizationUnit, User, AuditLog, Task, Delegation, AmountRule, CustomField, WorkflowStepTemplate } from '@/lib/repository/types';
 import { downloadTasksCsv } from '@/lib/export/approval-pdf';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import { ClientOnlyDate } from '@/components/common/client-only-date';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
+
+const CategoryFormModal = dynamic(
+  () => import('@/components/admin/category-form-modal').then(mod => mod.CategoryFormModal),
+  {
+    loading: () => (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm">
+        <div className="w-10 h-10 border-2 border-slate-200 border-t-slate-600 rounded-full animate-spin" />
+      </div>
+    ),
+  }
+);
 
 export default function AdminSettings() {
   const [activeTab, setActiveTab] = useState<'general' | 'org' | 'categories' | 'security' | 'logs' | 'delegation'>('general');
@@ -118,13 +130,11 @@ export default function AdminSettings() {
   const changeModalRef = useRef<HTMLDivElement>(null);
   const delegationModalRef = useRef<HTMLDivElement>(null);
   const addUserModalRef = useRef<HTMLDivElement>(null);
-  const catModalRef = useRef<HTMLDivElement>(null);
   const editUserModalRef = useRef<HTMLDivElement>(null);
   const unitModalRef = useRef<HTMLDivElement>(null);
   useFocusTrap(changeModalRef, isChangeModalOpen, () => setIsChangeModalOpen(false));
   useFocusTrap(delegationModalRef, showAddDelegationModal, () => setShowAddDelegationModal(false));
   useFocusTrap(addUserModalRef, showAddUserModal, () => setShowAddUserModal(false));
-  useFocusTrap(catModalRef, showAddCatModal || editingCategory !== null, () => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); });
   useFocusTrap(editUserModalRef, showEditUserModal, () => { setShowEditUserModal(false); setEditingUser(null); });
   useFocusTrap(unitModalRef, showAddUnitModal || editingUnit !== null, () => { setShowAddUnitModal(false); setEditingUnit(null); });
 
@@ -1227,249 +1237,29 @@ export default function AdminSettings() {
         </div>
       )}
 
-      {/* カテゴリー追加・編集モーダル */}
-      {(showAddCatModal || editingCategory) && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm animate-in fade-in duration-300">
-          <div className="absolute inset-0" onClick={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }} aria-hidden="true" />
-          <div
-            ref={catModalRef}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="cat-modal-title"
-            className="relative bg-white w-full max-w-lg rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300 flex flex-col max-h-[90vh]"
-          >
-            <div className="p-6 border-b flex items-center justify-between shrink-0">
-              <h3 id="cat-modal-title" className="text-lg font-bold text-[#191714]">{editingCategory ? 'カテゴリーを編集' : 'カテゴリーを追加'}</h3>
-              <button type="button" onClick={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる"><X className="w-5 h-5 text-slate-500" /></button>
-            </div>
-
-            {/* タブ */}
-            <div className="flex border-b shrink-0">
-              {([['basic', '基本設定'], ['fields', 'フォーム項目'], ['workflow', '承認フロー']] as const).map(([tab, label]) => (
-                <button
-                  key={tab}
-                  onClick={() => setCatFormTab(tab)}
-                  className={cn('flex-1 py-3 text-xs font-bold transition-colors', catFormTab === tab ? 'border-b-2 border-slate-900 text-slate-900' : 'text-slate-500 hover:text-slate-600')}
-                >
-                  {label}
-                  {tab === 'fields' && catFormFields.length > 0 && <span className="ml-1 text-blue-500">({catFormFields.length})</span>}
-                  {tab === 'workflow' && catFormWorkflow.length > 0 && <span className="ml-1 text-emerald-500">({catFormWorkflow.length})</span>}
-                </button>
-              ))}
-            </div>
-
-            <div className="p-6 overflow-y-auto flex-1">
-              {/* タブ1: 基本設定 */}
-              {catFormTab === 'basic' && (
-                <div className="space-y-4">
-                  <div className="space-y-1">
-                    <label htmlFor="cat-name" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">カテゴリー名</label>
-                    <input id="cat-name" type="text" value={catFormName} onChange={e => setCatFormName(e.target.value)} placeholder="例: 資格取得祝金申請"
-                      className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
-                  </div>
-                  <div className="space-y-1">
-                    <label htmlFor="cat-parent" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">大分類（親カテゴリー）</label>
-                    <select id="cat-parent" value={catFormParentId} onChange={e => setCatFormParentId(e.target.value)}
-                      className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
-                      <option value="">なし（大分類として追加）</option>
-                      {categories.filter(c => c.parentId === null).map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
-                    </select>
-                  </div>
-                  <div className="space-y-1">
-                    <label htmlFor="cat-sla" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">目標SLA（営業日）</label>
-                    <input id="cat-sla" type="number" min={1} max={90} value={catFormSla} onChange={e => setCatFormSla(Number(e.target.value))}
-                      className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
-                  </div>
-                  <div className="space-y-2 pt-2 border-t border-dashed border-slate-100">
-                    <div className="flex items-center justify-between">
-                      <label className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">金額閾値ルール（任意）</label>
-                      <button type="button" onClick={() => setCatFormAmountRules(prev => [...prev, { fieldLabel: '', minAmount: 0, requiredPosition: 'Division Manager' }])}
-                        className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors">+ ルールを追加</button>
-                    </div>
-                    {catFormAmountRules.map((rule, idx) => (
-                      <div key={idx} className="grid grid-cols-[1fr_1fr_auto] gap-2 items-start">
-                        <input type="text" placeholder="フィールド名（例: 金額）" value={rule.fieldLabel}
-                          onChange={e => setCatFormAmountRules(prev => prev.map((r, i) => i === idx ? { ...r, fieldLabel: e.target.value } : r))}
-                          className="h-9 px-3 bg-slate-50 border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
-                        <div className="flex gap-1.5 items-center">
-                          <span className="text-xs text-slate-500 font-bold shrink-0">¥</span>
-                          <input type="number" placeholder="閾値（例: 100000）" value={rule.minAmount || ''}
-                            onChange={e => setCatFormAmountRules(prev => prev.map((r, i) => i === idx ? { ...r, minAmount: Number(e.target.value) } : r))}
-                            className="flex-1 h-9 px-3 bg-slate-50 border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
-                        </div>
-                        <button type="button" onClick={() => setCatFormAmountRules(prev => prev.filter((_, i) => i !== idx))}
-                          className="h-9 w-9 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all">
-                          <Trash2 className="w-3.5 h-3.5" />
-                        </button>
-                        <div className="col-span-2">
-                          <select value={rule.requiredPosition}
-                            onChange={e => setCatFormAmountRules(prev => prev.map((r, i) => i === idx ? { ...r, requiredPosition: e.target.value } : r))}
-                            className="w-full h-9 px-3 bg-slate-50 border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
-                            {['Team Leader', 'General Manager', 'Division Manager', 'President'].map(p => (
-                              <option key={p} value={p}>{p} の承認が必要</option>
-                            ))}
-                          </select>
-                        </div>
-                      </div>
-                    ))}
-                    {catFormAmountRules.length === 0 && <p className="text-[10px] text-slate-500 font-medium px-1">ルールなし（すべての金額で同一フローを適用）</p>}
-                  </div>
-                </div>
-              )}
-
-              {/* タブ2: フォーム項目 */}
-              {catFormTab === 'fields' && (
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <p className="text-xs text-slate-500">申請フォームに表示されるカスタム項目を設定します。</p>
-                    <button type="button"
-                      onClick={() => setCatFormFields(prev => [...prev, { id: `f_${Date.now()}`, label: '', type: 'text', required: false }])}
-                      className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors whitespace-nowrap">+ 項目を追加</button>
-                  </div>
-                  {catFormFields.length === 0 && (
-                    <div className="py-8 text-center text-slate-500 text-xs">項目がありません。「+ 項目を追加」から追加してください。</div>
-                  )}
-                  {catFormFields.map((field, idx) => (
-                    <div key={field.id} className="p-3 bg-slate-50 border rounded-2xl space-y-2">
-                      <div className="flex gap-2 items-center">
-                        <input type="text" aria-label="項目名" placeholder="項目名（例: 受験料）" value={field.label}
-                          onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, label: e.target.value } : f))}
-                          className="flex-1 h-8 px-3 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
-                        <select aria-label="項目タイプ" value={field.type}
-                          onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, type: e.target.value as CustomField['type'], options: undefined } : f))}
-                          className="h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
-                          <option value="text">テキスト</option>
-                          <option value="textarea">長文テキスト</option>
-                          <option value="number">数値</option>
-                          <option value="date">日付</option>
-                          <option value="select">選択肢</option>
-                          <option value="checkbox">チェックボックス</option>
-                          <option value="file">ファイル添付</option>
-                        </select>
-                        <label className="flex items-center gap-1 text-[10px] font-bold text-slate-500 whitespace-nowrap">
-                          <input type="checkbox" checked={field.required}
-                            onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, required: e.target.checked } : f))} />
-                          必須
-                        </label>
-                        <button type="button" onClick={() => setCatFormFields(prev => prev.filter((_, i) => i !== idx))}
-                          className="h-8 w-8 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all shrink-0">
-                          <Trash2 className="w-3.5 h-3.5" />
-                        </button>
-                      </div>
-                      <input type="text" aria-label="プレースホルダー" placeholder="プレースホルダー（任意）" value={field.placeholder ?? ''}
-                        onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, placeholder: e.target.value } : f))}
-                        className="w-full h-7 px-3 bg-white border rounded-xl text-[11px] text-slate-500 focus:outline-none focus:border-slate-400 transition-all" />
-                      {field.type === 'select' && (
-                        <div className="space-y-1">
-                          <p className="text-[10px] text-slate-500 font-bold">選択肢（改行区切り）</p>
-                          <textarea rows={3} aria-label="選択肢（改行区切り）" value={(field.options ?? []).join('\n')}
-                            onChange={e => setCatFormFields(prev => prev.map((f, i) => i === idx ? { ...f, options: e.target.value.split('\n').filter(Boolean) } : f))}
-                            className="w-full px-3 py-2 bg-white border rounded-xl text-xs focus:outline-none focus:border-slate-400 transition-all resize-none" />
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {/* タブ3: 承認フロー */}
-              {catFormTab === 'workflow' && (
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <p className="text-xs text-slate-500">承認ルートのテンプレートを設定します。申請時に自動適用されます。</p>
-                    <button type="button"
-                      onClick={() => setCatFormWorkflow(prev => [...prev, { id: `wf_${Date.now()}`, label: '', approverType: 'direct_manager', stageIndex: prev.length }])}
-                      className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors whitespace-nowrap">+ ステップを追加</button>
-                  </div>
-                  {catFormWorkflow.length === 0 && (
-                    <div className="py-8 text-center text-slate-500 text-xs">ステップがありません。「+ ステップを追加」から追加してください。<br/>テンプレートなしの場合は申請者が手動で承認者を選択します。</div>
-                  )}
-                  {catFormWorkflow.map((step, idx) => (
-                    <div key={step.id} className="p-3 bg-slate-50 border rounded-2xl space-y-2">
-                      <div className="flex gap-2 items-center">
-                        <span className="text-[10px] font-black text-slate-500 w-5 shrink-0">{idx + 1}</span>
-                        <input type="text" aria-label="ステップ名" placeholder="ステップ名（例: 上長承認）" value={step.label}
-                          onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, label: e.target.value } : s))}
-                          className="flex-1 h-8 px-3 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
-                        <button type="button" onClick={() => setCatFormWorkflow(prev => prev.filter((_, i) => i !== idx))}
-                          className="h-8 w-8 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all shrink-0">
-                          <Trash2 className="w-3.5 h-3.5" />
-                        </button>
-                      </div>
-                      <div className="flex gap-2">
-                        <select aria-label="承認者タイプ" value={step.approverType}
-                          onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, approverType: e.target.value as ApproverType, approverUserId: undefined, approverRole: undefined, approverGroupIds: undefined } : s))}
-                          className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
-                          <option value="direct_manager">直属上長</option>
-                          <option value="second_manager">2段階上長</option>
-                          <option value="third_manager">3段階上長</option>
-                          <option value="specific_user">特定ユーザー</option>
-                          <option value="role">役職グループ</option>
-                          <option value="approval_group">承認グループ</option>
-                        </select>
-                        {step.approverType === 'role' && (
-                          <select aria-label="役職" value={step.approverRole ?? ''}
-                            onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, approverRole: e.target.value } : s))}
-                            className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
-                            <option value="">役職を選択</option>
-                            <option value="HR_Admin">人事担当（HR_Admin）</option>
-                            <option value="IT_Admin">IT担当（IT_Admin）</option>
-                            <option value="GA_Admin">総務担当（GA_Admin）</option>
-                          </select>
-                        )}
-                        {step.approverType === 'specific_user' && (
-                          <select aria-label="特定ユーザー" value={step.approverUserId ?? ''}
-                            onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, approverUserId: e.target.value } : s))}
-                            className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
-                            <option value="">ユーザーを選択</option>
-                            {users.filter(u => u.status === 'active').map(u => <option key={u.id} value={u.id}>{u.name}</option>)}
-                          </select>
-                        )}
-                        {step.approverType === 'approval_group' && (
-                          <select aria-label="並列設定" value={step.parallelType ?? 'or'}
-                            onChange={e => setCatFormWorkflow(prev => prev.map((s, i) => i === idx ? { ...s, parallelType: e.target.value as 'or' | 'and' } : s))}
-                            className="h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
-                            <option value="or">OR（誰か1名）</option>
-                            <option value="and">AND（全員）</option>
-                          </select>
-                        )}
-                      </div>
-                      {step.approverType === 'approval_group' && (
-                        <div className="space-y-1">
-                          <p className="text-[10px] text-slate-500 font-bold">グループメンバー</p>
-                          <div className="flex flex-wrap gap-1">
-                            {users.filter(u => u.status === 'active').map(u => {
-                              const selected = (step.approverGroupIds ?? []).includes(u.id);
-                              return (
-                                <button key={u.id} type="button"
-                                  onClick={() => setCatFormWorkflow(prev => prev.map((s, i) => {
-                                    if (i !== idx) return s;
-                                    const ids = s.approverGroupIds ?? [];
-                                    return { ...s, approverGroupIds: selected ? ids.filter(id => id !== u.id) : [...ids, u.id] };
-                                  }))}
-                                  className={cn('px-2 py-0.5 rounded-full text-[10px] font-bold transition-all border', selected ? 'bg-slate-900 text-white border-slate-900' : 'bg-white text-slate-500 border-slate-200 hover:border-slate-400')}>
-                                  {u.name}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            <div className="p-6 border-t flex gap-3 shrink-0">
-              <button onClick={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }} className="flex-1 h-10 border border-slate-200 rounded-xl text-sm font-bold text-slate-600 hover:bg-slate-50 transition-all">キャンセル</button>
-              <button onClick={handleSaveCategory} disabled={!catFormName} className="flex-[2] h-10 bg-slate-900 text-white rounded-xl text-sm font-bold hover:bg-black transition-all disabled:opacity-40">
-                {editingCategory ? '変更を保存' : '追加する'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* カテゴリー追加・編集モーダル — next/dynamic で遅延ロード */}
+      <CategoryFormModal
+        show={showAddCatModal || editingCategory !== null}
+        editingCategory={editingCategory}
+        catFormTab={catFormTab}
+        catFormName={catFormName}
+        catFormParentId={catFormParentId}
+        catFormSla={catFormSla}
+        catFormAmountRules={catFormAmountRules}
+        catFormFields={catFormFields}
+        catFormWorkflow={catFormWorkflow}
+        categories={categories}
+        users={users}
+        onTabChange={setCatFormTab}
+        onNameChange={setCatFormName}
+        onParentChange={setCatFormParentId}
+        onSlaChange={setCatFormSla}
+        onAmountRulesChange={setCatFormAmountRules}
+        onFieldsChange={setCatFormFields}
+        onWorkflowChange={setCatFormWorkflow}
+        onClose={() => { setShowAddCatModal(false); setEditingCategory(null); setCatFormTab('basic'); }}
+        onSave={handleSaveCategory}
+      />
 
       {/* ユーザー編集モーダル */}
       {showEditUserModal && editingUser && (

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -1,31 +1,16 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import {
   Search,
   Filter,
   MoreHorizontal,
-  ArrowUpRight,
-  CheckCircle2,
-  Clock,
-  AlertCircle,
-  Calendar,
-  MessageSquare,
-  History,
-  ShieldCheck,
-  ChevronRight,
-  FileText,
-  Archive,
-  Copy,
   X,
   Download,
-  Printer,
-  AlarmClock,
 } from 'lucide-react';
 import { downloadTasksCsv, printApprovalPdf } from '@/lib/export/approval-pdf';
-import { isMyTurn } from '@/lib/workflow-utils';
-import { useRouter } from 'next/navigation';
 import { getDataProvider } from '@/lib/repository/factory';
 import { Task, AuditLog, Category, Delegation } from '@/lib/repository/types';
 import { useAuth } from '@/context/auth-context';
@@ -34,9 +19,19 @@ import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
 
+const TaskDetailPanel = dynamic(
+  () => import('@/components/inbox/task-detail-panel').then(mod => mod.TaskDetailPanel),
+  {
+    loading: () => (
+      <div className="flex-1 flex items-center justify-center bg-white">
+        <div className="w-8 h-8 border-2 border-slate-200 border-t-slate-600 rounded-full animate-spin" />
+      </div>
+    ),
+  }
+);
+
 export default function RequestInbox() {
   const { user } = useAuth();
-  const router = useRouter();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [logs, setLogs] = useState<AuditLog[]>([]);
@@ -640,396 +635,25 @@ export default function RequestInbox() {
         </div>
       )}
 
-      {/* Detail Panel — デスクトップ: flex-1。モバイル: 詳細選択時のみ full-screen */}
-      <div className={cn(
-        "overflow-y-auto bg-white p-4 md:p-6",
-        "flex-1",
-        selectedTask
-          ? "block fixed inset-0 z-30 md:relative md:inset-auto md:z-auto animate-in slide-in-from-right-4 duration-300"
-          : "hidden md:block",
-      )}>
-        {selectedTask ? (
-          <div className="max-w-3xl mx-auto space-y-6">
-            {/* モバイル専用: 戻るボタン */}
-            <button
-              onClick={() => setSelectedTask(null)}
-              className="md:hidden flex items-center gap-2 text-xs font-bold text-slate-500 hover:text-slate-900 transition-colors mb-2 -ml-1"
-            >
-              <ChevronRight className="w-4 h-4 rotate-180" />
-              一覧に戻る
-            </button>
-            {/* SLAエスカレーションバナー */}
-            {selectedTask.status !== 'completed' && new Date(selectedTask.dueDate) < now && (() => {
-              const overdueDays = Math.floor((now.getTime() - new Date(selectedTask.dueDate).getTime()) / 86400000);
-              const urgency = overdueDays >= 5 ? 'critical' : overdueDays >= 2 ? 'high' : 'medium';
-              return (
-                <div className={cn(
-                  "flex items-start gap-3 px-4 py-3 rounded-2xl border animate-in fade-in duration-300",
-                  urgency === 'critical' ? "bg-rose-50 border-rose-200" :
-                  urgency === 'high'     ? "bg-orange-50 border-orange-200" :
-                                          "bg-amber-50 border-amber-200"
-                )}>
-                  <AlarmClock className={cn(
-                    "w-4 h-4 mt-0.5 shrink-0",
-                    urgency === 'critical' ? "text-rose-600" : urgency === 'high' ? "text-orange-600" : "text-amber-600"
-                  )} />
-                  <div className="flex-1 min-w-0">
-                    <p className={cn(
-                      "text-xs font-black",
-                      urgency === 'critical' ? "text-rose-700" : urgency === 'high' ? "text-orange-700" : "text-amber-700"
-                    )}>
-                      SLA 超過 — {overdueDays}日経過
-                      {urgency === 'critical' && '（緊急対応が必要です）'}
-                    </p>
-                    <p className={cn(
-                      "text-[10px] font-medium mt-0.5",
-                      urgency === 'critical' ? "text-rose-700" : urgency === 'high' ? "text-orange-700" : "text-amber-700"
-                    )}>
-                      期限: <ClientOnlyDate date={selectedTask.dueDate} /> ／ 現在の担当者が未処理のため遅延しています
-                    </p>
-                  </div>
-                </div>
-              );
-            })()}
-            <header className="space-y-3">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="px-3 py-1 rounded-full bg-slate-100 border text-[10px] font-black text-slate-500 uppercase tracking-widest">
-                    {selectedTask.category}
-                  </span>
-                  {selectedTask.taskType === 'circulation' && (
-                    <span className="px-2 py-1 rounded-full bg-teal-50 border border-teal-200 text-[10px] font-black text-teal-600 uppercase tracking-widest">
-                      回覧
-                    </span>
-                  )}
-                  <span className="text-[10px] font-bold text-slate-500">ID: {selectedTask.id}</span>
-                </div>
-                <button
-                  onClick={handleExportPdf}
-                  title="稟議書をPDFで出力"
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-black text-slate-500 border border-slate-200 rounded-lg hover:bg-slate-50 hover:border-slate-400 transition-all uppercase tracking-widest"
-                  aria-label="稟議書PDF出力"
-                >
-                  <Printer className="w-3.5 h-3.5" />
-                  稟議書
-                </button>
-              </div>
-              <h1 className="text-xl font-black tracking-tight text-[#191714] leading-tight">
-                {selectedTask.title}
-              </h1>
-              <div className="flex items-center gap-6 py-2 border-y border-slate-100">
-                <div className="space-y-1">
-                  <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">申請者</div>
-                  <div className="flex items-center gap-2">
-                    <div className="w-6 h-6 rounded-lg bg-slate-100 flex items-center justify-center text-xs font-bold">U</div>
-                    <span className="text-xs font-bold text-[#191714]">User {selectedTask.requesterId.split('_').pop()}</span>
-                  </div>
-                </div>
-                <div className="space-y-1">
-                  <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">期限 (SLA)</div>
-                  <div className="flex items-center gap-2">
-                    <Calendar className="w-4 h-4 text-slate-500" />
-                    <span className="text-xs font-bold text-[#191714]"><ClientOnlyDate date={selectedTask.dueDate} /></span>
-                  </div>
-                </div>
-              </div>
-            </header>
-
-            <section className="space-y-4">
-              <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
-                <FileText className="w-4 h-4" />
-                依頼内容の詳細
-              </h3>
-              <div className="text-sm font-medium text-slate-600 leading-relaxed bg-slate-50/50 p-6 rounded-2xl border border-slate-100">
-                {selectedTask.description || <span className="text-slate-500 italic">追加の説明はありません。</span>}
-              </div>
-              
-              {/* Dynamic Form Custom Data Rendering */}
-              {selectedTask.customData && Object.keys(selectedTask.customData).length > 0 && (
-                <div className="mt-6 space-y-4 bg-white p-6 rounded-2xl border border-slate-200">
-                  <h4 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-4">追加フォーム入力内容</h4>
-                  <div className="grid grid-cols-2 gap-y-4">
-                    {Object.entries(selectedTask.customData).map(([key, value]) => (
-                      <div key={key} className="space-y-1">
-                        <div className="text-[10px] font-bold text-slate-500 uppercase">{key}</div>
-                        <div className="text-sm font-bold text-[#191714]">{value as string}</div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </section>
-
-            {/* Approval Route Visual */}
-            <section className="space-y-6">
-              <div className="flex items-center justify-between">
-                <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
-                  <ShieldCheck className="w-4 h-4" />
-                  現在の承認ステータス
-                </h3>
-                {selectedTask.approvalRoute && selectedTask.approvalRoute.length > 0 && (() => {
-                  const completed = selectedTask.approvalRoute.filter(s => s.status === 'approved').length;
-                  const total = selectedTask.approvalRoute.length;
-                  return (
-                    <span className="bg-slate-100 text-slate-700 px-3 py-1 rounded-full text-xs font-bold">
-                      {completed} / {total} ステップ完了
-                    </span>
-                  );
-                })()}
-              </div>
-              {/* AND 並列ステージのヒント */}
-              {(() => {
-                const activeStageSteps = selectedTask.approvalRoute.filter(
-                  s => s.status === 'pending' && s.parallelType === 'and'
-                );
-                if (activeStageSteps.length < 2) return null;
-                const names = activeStageSteps.map(s => s.userName).join('・');
-                return (
-                  <div className="flex items-center gap-2 px-4 py-2.5 bg-violet-50 border border-violet-100 rounded-2xl">
-                    <span className="text-[10px] font-black text-violet-500 uppercase tracking-widest">AND 並列</span>
-                    <span className="text-xs font-bold text-violet-700">{names} が同時に承認待ちです（全員の承認が必要）</span>
-                  </div>
-                );
-              })()}
-              <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-                {selectedTask.approvalRoute?.map((step, idx) => {
-                  const isDelegated = !!step.delegatedBy;
-                  const delegateUser = isDelegated ? allUsers.find(u => u.id === step.delegatedBy) : null;
-                  const isParallel = step.parallelType !== undefined;
-                  const stepLabel =
-                    selectedTask.taskType === 'circulation'
-                      ? step.status === 'approved' ? '確認済' : '未確認'
-                      : step.status === 'approved' ? '承認済' : step.status === 'rejected' ? '差し戻し' : '待機中';
-                  return (
-                    <div key={idx} className="relative p-4 bg-white border border-slate-200 rounded-2xl hover:border-slate-400 transition-all notion-shadow group">
-                      {/* 並列バッジ */}
-                      {isParallel && (
-                        <span className={cn(
-                          "absolute top-2 left-3 text-[8px] font-black uppercase tracking-widest px-1.5 py-0.5 rounded-full border",
-                          step.parallelType === 'and' ? "bg-violet-50 text-violet-500 border-violet-100" : "bg-amber-50 text-amber-500 border-amber-100",
-                        )}>
-                          {step.parallelType === 'and' ? 'AND' : 'OR'}
-                        </span>
-                      )}
-                      <div className="absolute top-3 right-3">
-                        {step.status === 'approved' ? (
-                          <CheckCircle2 className="w-4 h-4 text-emerald-500" />
-                        ) : step.status === 'rejected' ? (
-                          <AlertCircle className="w-4 h-4 text-rose-400" />
-                        ) : (
-                          <Clock className="w-4 h-4 text-slate-200" />
-                        )}
-                      </div>
-                      {step.avatar
-                        ? <Image src={step.avatar} width={40} height={40} alt={step.userName} className="w-10 h-10 rounded-xl bg-slate-100 mb-3 mt-2" />
-                        : <div className="w-10 h-10 rounded-xl bg-slate-100 mb-3 mt-2" />
-                      }
-                      <div className="text-[9px] font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">{step.position}</div>
-                      <div className="text-xs font-bold text-[#191714]">{step.userName}</div>
-                      {isDelegated && delegateUser && (
-                        <div className="text-[9px] font-bold text-violet-500 mt-0.5">代理: {delegateUser.name}</div>
-                      )}
-                      <div className="mt-2 flex items-center gap-1.5 flex-wrap">
-                        <span className={cn(
-                          "text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border",
-                          step.status === 'approved' ? "bg-emerald-50 text-emerald-600 border-emerald-100" :
-                          step.status === 'rejected' ? "bg-rose-50 text-rose-500 border-rose-100" :
-                          "bg-slate-50 text-slate-500 border-slate-100"
-                        )}>
-                          {stepLabel}
-                        </span>
-                        {step.status === 'pending' && (
-                          <button
-                            onClick={() => handleOpenChangeApprover(idx)}
-                            className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border border-slate-200 text-slate-500 hover:border-blue-400 hover:text-blue-600 hover:bg-blue-50 transition-all"
-                            aria-label={`${step.userName}の承認者を変更`}
-                          >
-                            変更
-                          </button>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* CC Users Compact Display */}
-              {selectedTask.ccRoute && selectedTask.ccRoute.length > 0 && (
-                <div className="pt-2 animate-in fade-in duration-500">
-                  <div className="flex items-center gap-2 mb-3">
-                    <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">CC（共有先）</div>
-                    <div className="h-px flex-1 bg-slate-100" />
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {selectedTask.ccRoute.map((cc, idx) => (
-                      <div key={idx} className="flex items-center gap-2 pl-1 pr-3 py-1 bg-slate-50 border border-slate-100 rounded-full hover:bg-slate-100 transition-colors group cursor-default">
-                        {cc.avatar
-                          ? <Image src={cc.avatar} width={20} height={20} alt={cc.userName} className="w-5 h-5 rounded-full bg-slate-200" />
-                          : <div className="w-5 h-5 rounded-full bg-slate-200" />
-                        }
-                        <div className="flex flex-col">
-                          <span className="text-[10px] font-bold text-[#191714] leading-tight">{cc.userName}</span>
-                          <span className="text-[8px] font-medium text-slate-500 leading-tight uppercase tracking-tighter">{cc.position}</span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </section>
-
-            {/* Audit Logs (Timeline) */}
-            <section className="space-y-6">
-              <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
-                <History className="w-4 h-4" />
-                アクティビティ履歴
-              </h3>
-              <div className="space-y-8 border-l-2 border-slate-100 pl-6 ml-2 relative">
-                {logs.length > 0 ? logs.map((log, idx) => {
-                  const getActionTheme = (action: string) => {
-                    switch (action) {
-                      case 'submit': return { label: '提出', color: 'bg-blue-600', icon: <ArrowUpRight className="w-3 h-3 text-white" /> };
-                      case 'approve': return { label: '承認', color: 'bg-emerald-500', icon: <CheckCircle2 className="w-3 h-3 text-white" /> };
-                      case 'reject': return { label: '却下', color: 'bg-rose-500', icon: <AlertCircle className="w-3 h-3 text-white" /> };
-                      case 'reassign': return { label: '担当者変更', color: 'bg-amber-500', icon: <History className="w-3 h-3 text-white" /> };
-                      case 'comment': return { label: 'コメント', color: 'bg-slate-400', icon: <MessageSquare className="w-3 h-3 text-white" /> };
-                      default: return { label: action, color: 'bg-slate-900', icon: <FileText className="w-3 h-3 text-white" /> };
-                    }
-                  };
-                  const theme = getActionTheme(log.action);
-                  
-                  return (
-                    <div key={log.id} className="relative animate-in fade-in slide-in-from-left-2 duration-300" style={{ animationDelay: `${idx * 100}ms` }}>
-                      <div className={cn(
-                        "absolute -left-[35px] top-0 w-6 h-6 rounded-full flex items-center justify-center ring-4 ring-white shadow-sm",
-                        theme.color
-                      )}>
-                        {theme.icon}
-                      </div>
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            <span className="text-xs font-black text-[#191714]">{log.userName}</span>
-                            <span className={cn(
-                              "px-1.5 py-0.5 rounded text-[8px] font-black uppercase tracking-tight text-white",
-                              theme.color
-                            )}>
-                              {theme.label}
-                            </span>
-                          </div>
-                          <div className="text-[10px] font-bold text-slate-500">
-                            <ClientOnlyDate date={log.timestamp} showTime />
-                          </div>
-                        </div>
-                        <div className="p-4 bg-slate-50/50 border border-slate-100 rounded-2xl text-xs font-medium text-slate-600 leading-relaxed">
-                          {log.comment || `${theme.label}されました。`}
-                        </div>
-                      </div>
-                    </div>
-                  );
-                }) : (
-                  <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest italic py-4">履歴データはまだありません</div>
-                )}
-              </div>
-            </section>
-
-            {/* In-App Messaging (Comments) */}
-            <section className="space-y-6 pt-4 border-t">
-              <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
-                <MessageSquare className="w-4 h-4" />
-                連絡・コメントを追加
-              </h3>
-              <div className="flex gap-4">
-                <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center text-xs font-bold shrink-0">
-                  {user?.avatar ? <Image src={user.avatar} width={40} height={40} className="w-full h-full rounded-full object-cover" alt="avatar" /> : 'U'}
-                </div>
-                <div className="flex-1 space-y-3">
-                  <textarea
-                    rows={3}
-                    aria-label="コメントを入力"
-                    placeholder="申請内容に関する質問や連絡事項を入力してください..."
-                    className="w-full p-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm font-medium focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all resize-none"
-                    value={commentText}
-                    onChange={(e) => setCommentText(e.target.value)}
-                  />
-                  <div className="flex justify-end">
-                    <button 
-                      onClick={handleAddComment}
-                      disabled={!commentText.trim()}
-                      className="px-6 py-2.5 bg-[#191714] text-white rounded-xl text-xs font-bold hover:bg-black transition-all disabled:opacity-30 disabled:pointer-events-none"
-                    >
-                      コメントを送信する
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <footer className="pt-10 space-y-3">
-              {/* 代決コンテキストバナー */}
-              {user && (() => {
-                const delegation = delegations.find(d =>
-                  d.delegateId === user.id && d.isActive &&
-                  selectedTask.approvalRoute.some(s => s.userId === d.delegatorId && s.status === 'pending')
-                );
-                if (!delegation) return null;
-                const delegatorName = allUsers.find(u => u.id === delegation.delegatorId)?.name ?? delegation.delegatorId;
-                return (
-                  <div className="flex items-center gap-2 px-4 py-2 bg-violet-50 border border-violet-100 rounded-2xl">
-                    <span className="text-[10px] font-black text-violet-500 uppercase tracking-widest shrink-0">代決</span>
-                    <span className="text-xs font-bold text-violet-700"><span className="text-violet-900">{delegatorName}</span> の代理として承認します</span>
-                  </div>
-                );
-              })()}
-              <div className="flex items-center gap-4">
-                {selectedTask.status === 'completed' ? (
-                  <button
-                    onClick={() => router.push(`/request?reuseTaskId=${selectedTask.id}`)}
-                    className="flex-1 py-4 bg-slate-900 mx-auto text-white rounded-2xl font-bold flex items-center justify-center gap-2 hover:bg-black transition-all hover:shadow-xl hover:-translate-y-1"
-                  >
-                    <Copy className="w-5 h-5" />
-                    再利用して申請
-                  </button>
-                ) : selectedTask.taskType === 'circulation' && user && selectedTask.approvalRoute.some(s => s.userId === user.id && s.status === 'pending') ? (
-                  <button
-                    onClick={handleAcknowledge}
-                    disabled={isProcessing}
-                    className="flex-1 py-4 bg-emerald-600 text-white rounded-2xl font-bold hover:bg-emerald-700 transition-all hover:shadow-xl hover:-translate-y-1 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    確認済みにする
-                  </button>
-                ) : user && isMyTurn(selectedTask, user.id, delegations) ? (
-                  <>
-                    <button
-                      onClick={handleApprove}
-                      disabled={isProcessing}
-                      className="flex-1 py-4 bg-slate-900 text-white rounded-2xl font-bold hover:bg-black transition-all hover:shadow-xl hover:-translate-y-1 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {isProcessing ? '処理中...' : '承認・受理する'}
-                    </button>
-                    <button
-                      onClick={handleReject}
-                      disabled={isProcessing}
-                      className="px-8 py-4 bg-white border border-slate-200 text-rose-600 rounded-2xl font-bold hover:bg-rose-50 hover:border-rose-200 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      差し戻し
-                    </button>
-                  </>
-                ) : (
-                  <div className="flex-1 py-4 text-center text-sm font-bold text-slate-500 border border-dashed rounded-2xl">
-                    現在あなたの対応番ではありません
-                  </div>
-                )}
-              </div>
-            </footer>
-          </div>
-        ) : (
-          <div className="h-full flex flex-col items-center justify-center text-slate-500">
-            <Archive className="w-16 h-16 opacity-10 mb-4" />
-            <p className="text-sm font-bold uppercase tracking-widest opacity-30">依頼を選択してください</p>
-          </div>
-        )}
-      </div>
+      {/* Detail Panel — next/dynamic で遅延ロード */}
+      <TaskDetailPanel
+        selectedTask={selectedTask}
+        onClose={() => setSelectedTask(null)}
+        logs={logs}
+        allUsers={allUsers}
+        delegations={delegations}
+        user={user}
+        isProcessing={isProcessing}
+        commentText={commentText}
+        onCommentChange={setCommentText}
+        now={now}
+        onApprove={handleApprove}
+        onAcknowledge={handleAcknowledge}
+        onReject={handleReject}
+        onOpenChangeApprover={handleOpenChangeApprover}
+        onExportPdf={handleExportPdf}
+        onAddComment={handleAddComment}
+      />
     </div>
   );
 }

--- a/src/components/admin/category-form-modal.tsx
+++ b/src/components/admin/category-form-modal.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { useRef } from 'react';
+import { X, Trash2 } from 'lucide-react';
+import { Category, User, AmountRule, CustomField, WorkflowStepTemplate, ApproverType } from '@/lib/repository/types';
+import { cn } from '@/lib/utils';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+
+interface CategoryFormModalProps {
+  show: boolean;
+  editingCategory: Category | null;
+  catFormTab: 'basic' | 'fields' | 'workflow';
+  catFormName: string;
+  catFormParentId: string;
+  catFormSla: number;
+  catFormAmountRules: AmountRule[];
+  catFormFields: CustomField[];
+  catFormWorkflow: WorkflowStepTemplate[];
+  categories: Category[];
+  users: User[];
+  onTabChange: (tab: 'basic' | 'fields' | 'workflow') => void;
+  onNameChange: (n: string) => void;
+  onParentChange: (id: string) => void;
+  onSlaChange: (n: number) => void;
+  onAmountRulesChange: React.Dispatch<React.SetStateAction<AmountRule[]>>;
+  onFieldsChange: React.Dispatch<React.SetStateAction<CustomField[]>>;
+  onWorkflowChange: React.Dispatch<React.SetStateAction<WorkflowStepTemplate[]>>;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+export function CategoryFormModal({
+  show,
+  editingCategory,
+  catFormTab,
+  catFormName,
+  catFormParentId,
+  catFormSla,
+  catFormAmountRules,
+  catFormFields,
+  catFormWorkflow,
+  categories,
+  users,
+  onTabChange,
+  onNameChange,
+  onParentChange,
+  onSlaChange,
+  onAmountRulesChange,
+  onFieldsChange,
+  onWorkflowChange,
+  onClose,
+  onSave,
+}: CategoryFormModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(modalRef, show, onClose);
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm animate-in fade-in duration-300">
+      <div className="absolute inset-0" onClick={onClose} aria-hidden="true" />
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cat-modal-title"
+        className="relative bg-white w-full max-w-lg rounded-3xl shadow-2xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-300 flex flex-col max-h-[90vh]"
+      >
+        <div className="p-6 border-b flex items-center justify-between shrink-0">
+          <h3 id="cat-modal-title" className="text-lg font-bold text-[#191714]">{editingCategory ? 'カテゴリーを編集' : 'カテゴリーを追加'}</h3>
+          <button type="button" onClick={onClose} className="p-1.5 hover:bg-slate-100 rounded-lg transition-colors" aria-label="閉じる">
+            <X className="w-5 h-5 text-slate-500" />
+          </button>
+        </div>
+
+        {/* タブ */}
+        <div className="flex border-b shrink-0">
+          {([['basic', '基本設定'], ['fields', 'フォーム項目'], ['workflow', '承認フロー']] as const).map(([tab, label]) => (
+            <button
+              key={tab}
+              onClick={() => onTabChange(tab)}
+              className={cn('flex-1 py-3 text-xs font-bold transition-colors', catFormTab === tab ? 'border-b-2 border-slate-900 text-slate-900' : 'text-slate-500 hover:text-slate-600')}
+            >
+              {label}
+              {tab === 'fields' && catFormFields.length > 0 && <span className="ml-1 text-blue-500">({catFormFields.length})</span>}
+              {tab === 'workflow' && catFormWorkflow.length > 0 && <span className="ml-1 text-emerald-500">({catFormWorkflow.length})</span>}
+            </button>
+          ))}
+        </div>
+
+        <div className="p-6 overflow-y-auto flex-1">
+          {/* タブ1: 基本設定 */}
+          {catFormTab === 'basic' && (
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <label htmlFor="cat-name" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">カテゴリー名</label>
+                <input id="cat-name" type="text" value={catFormName} onChange={e => onNameChange(e.target.value)} placeholder="例: 資格取得祝金申請"
+                  className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
+              </div>
+              <div className="space-y-1">
+                <label htmlFor="cat-parent" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">大分類（親カテゴリー）</label>
+                <select id="cat-parent" value={catFormParentId} onChange={e => onParentChange(e.target.value)}
+                  className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all">
+                  <option value="">なし（大分類として追加）</option>
+                  {categories.filter(c => c.parentId === null).map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                </select>
+              </div>
+              <div className="space-y-1">
+                <label htmlFor="cat-sla" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">目標SLA（営業日）</label>
+                <input id="cat-sla" type="number" min={1} max={90} value={catFormSla} onChange={e => onSlaChange(Number(e.target.value))}
+                  className="w-full h-10 px-4 bg-slate-50 border rounded-xl font-bold text-sm focus:outline-none focus:border-slate-400 transition-all" />
+              </div>
+              <div className="space-y-2 pt-2 border-t border-dashed border-slate-100">
+                <div className="flex items-center justify-between">
+                  <label className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">金額閾値ルール（任意）</label>
+                  <button type="button" onClick={() => onAmountRulesChange(prev => [...prev, { fieldLabel: '', minAmount: 0, requiredPosition: 'Division Manager' }])}
+                    className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors">+ ルールを追加</button>
+                </div>
+                {catFormAmountRules.map((rule, idx) => (
+                  <div key={idx} className="grid grid-cols-[1fr_1fr_auto] gap-2 items-start">
+                    <input type="text" placeholder="フィールド名（例: 金額）" value={rule.fieldLabel}
+                      onChange={e => onAmountRulesChange(prev => prev.map((r, i) => i === idx ? { ...r, fieldLabel: e.target.value } : r))}
+                      className="h-9 px-3 bg-slate-50 border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
+                    <div className="flex gap-1.5 items-center">
+                      <span className="text-xs text-slate-500 font-bold shrink-0">¥</span>
+                      <input type="number" placeholder="閾値（例: 100000）" value={rule.minAmount || ''}
+                        onChange={e => onAmountRulesChange(prev => prev.map((r, i) => i === idx ? { ...r, minAmount: Number(e.target.value) } : r))}
+                        className="flex-1 h-9 px-3 bg-slate-50 border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
+                    </div>
+                    <button type="button" onClick={() => onAmountRulesChange(prev => prev.filter((_, i) => i !== idx))}
+                      className="h-9 w-9 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all">
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                    <div className="col-span-2">
+                      <select value={rule.requiredPosition}
+                        onChange={e => onAmountRulesChange(prev => prev.map((r, i) => i === idx ? { ...r, requiredPosition: e.target.value } : r))}
+                        className="w-full h-9 px-3 bg-slate-50 border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
+                        {['Team Leader', 'General Manager', 'Division Manager', 'President'].map(p => (
+                          <option key={p} value={p}>{p} の承認が必要</option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                ))}
+                {catFormAmountRules.length === 0 && <p className="text-[10px] text-slate-500 font-medium px-1">ルールなし（すべての金額で同一フローを適用）</p>}
+              </div>
+            </div>
+          )}
+
+          {/* タブ2: フォーム項目 */}
+          {catFormTab === 'fields' && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <p className="text-xs text-slate-500">申請フォームに表示されるカスタム項目を設定します。</p>
+                <button type="button"
+                  onClick={() => onFieldsChange(prev => [...prev, { id: `f_${Date.now()}`, label: '', type: 'text', required: false }])}
+                  className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors whitespace-nowrap">+ 項目を追加</button>
+              </div>
+              {catFormFields.length === 0 && (
+                <div className="py-8 text-center text-slate-500 text-xs">項目がありません。「+ 項目を追加」から追加してください。</div>
+              )}
+              {catFormFields.map((field, idx) => (
+                <div key={field.id} className="p-3 bg-slate-50 border rounded-2xl space-y-2">
+                  <div className="flex gap-2 items-center">
+                    <input type="text" aria-label="項目名" placeholder="項目名（例: 受験料）" value={field.label}
+                      onChange={e => onFieldsChange(prev => prev.map((f, i) => i === idx ? { ...f, label: e.target.value } : f))}
+                      className="flex-1 h-8 px-3 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
+                    <select aria-label="項目タイプ" value={field.type}
+                      onChange={e => onFieldsChange(prev => prev.map((f, i) => i === idx ? { ...f, type: e.target.value as CustomField['type'], options: undefined } : f))}
+                      className="h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
+                      <option value="text">テキスト</option>
+                      <option value="textarea">長文テキスト</option>
+                      <option value="number">数値</option>
+                      <option value="date">日付</option>
+                      <option value="select">選択肢</option>
+                      <option value="checkbox">チェックボックス</option>
+                      <option value="file">ファイル添付</option>
+                    </select>
+                    <label className="flex items-center gap-1 text-[10px] font-bold text-slate-500 whitespace-nowrap">
+                      <input type="checkbox" checked={field.required}
+                        onChange={e => onFieldsChange(prev => prev.map((f, i) => i === idx ? { ...f, required: e.target.checked } : f))} />
+                      必須
+                    </label>
+                    <button type="button" onClick={() => onFieldsChange(prev => prev.filter((_, i) => i !== idx))}
+                      className="h-8 w-8 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all shrink-0">
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                  <input type="text" aria-label="プレースホルダー" placeholder="プレースホルダー（任意）" value={field.placeholder ?? ''}
+                    onChange={e => onFieldsChange(prev => prev.map((f, i) => i === idx ? { ...f, placeholder: e.target.value } : f))}
+                    className="w-full h-7 px-3 bg-white border rounded-xl text-[11px] text-slate-500 focus:outline-none focus:border-slate-400 transition-all" />
+                  {field.type === 'select' && (
+                    <div className="space-y-1">
+                      <p className="text-[10px] text-slate-500 font-bold">選択肢（改行区切り）</p>
+                      <textarea rows={3} aria-label="選択肢（改行区切り）" value={(field.options ?? []).join('\n')}
+                        onChange={e => onFieldsChange(prev => prev.map((f, i) => i === idx ? { ...f, options: e.target.value.split('\n').filter(Boolean) } : f))}
+                        className="w-full px-3 py-2 bg-white border rounded-xl text-xs focus:outline-none focus:border-slate-400 transition-all resize-none" />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* タブ3: 承認フロー */}
+          {catFormTab === 'workflow' && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <p className="text-xs text-slate-500">承認ルートのテンプレートを設定します。申請時に自動適用されます。</p>
+                <button type="button"
+                  onClick={() => onWorkflowChange(prev => [...prev, { id: `wf_${Date.now()}`, label: '', approverType: 'direct_manager', stageIndex: prev.length }])}
+                  className="text-[10px] font-black text-blue-600 hover:text-blue-800 transition-colors whitespace-nowrap">+ ステップを追加</button>
+              </div>
+              {catFormWorkflow.length === 0 && (
+                <div className="py-8 text-center text-slate-500 text-xs">ステップがありません。「+ ステップを追加」から追加してください。<br/>テンプレートなしの場合は申請者が手動で承認者を選択します。</div>
+              )}
+              {catFormWorkflow.map((step, idx) => (
+                <div key={step.id} className="p-3 bg-slate-50 border rounded-2xl space-y-2">
+                  <div className="flex gap-2 items-center">
+                    <span className="text-[10px] font-black text-slate-500 w-5 shrink-0">{idx + 1}</span>
+                    <input type="text" aria-label="ステップ名" placeholder="ステップ名（例: 上長承認）" value={step.label}
+                      onChange={e => onWorkflowChange(prev => prev.map((s, i) => i === idx ? { ...s, label: e.target.value } : s))}
+                      className="flex-1 h-8 px-3 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all" />
+                    <button type="button" onClick={() => onWorkflowChange(prev => prev.filter((_, i) => i !== idx))}
+                      className="h-8 w-8 flex items-center justify-center text-slate-500 hover:text-rose-600 hover:bg-rose-50 rounded-xl transition-all shrink-0">
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                  <div className="flex gap-2">
+                    <select aria-label="承認者タイプ" value={step.approverType}
+                      onChange={e => onWorkflowChange(prev => prev.map((s, i) => i === idx ? { ...s, approverType: e.target.value as ApproverType, approverUserId: undefined, approverRole: undefined, approverGroupIds: undefined } : s))}
+                      className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
+                      <option value="direct_manager">直属上長</option>
+                      <option value="second_manager">2段階上長</option>
+                      <option value="third_manager">3段階上長</option>
+                      <option value="specific_user">特定ユーザー</option>
+                      <option value="role">役職グループ</option>
+                      <option value="approval_group">承認グループ</option>
+                    </select>
+                    {step.approverType === 'role' && (
+                      <select aria-label="役職" value={step.approverRole ?? ''}
+                        onChange={e => onWorkflowChange(prev => prev.map((s, i) => i === idx ? { ...s, approverRole: e.target.value } : s))}
+                        className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
+                        <option value="">役職を選択</option>
+                        <option value="HR_Admin">人事担当（HR_Admin）</option>
+                        <option value="IT_Admin">IT担当（IT_Admin）</option>
+                        <option value="GA_Admin">総務担当（GA_Admin）</option>
+                      </select>
+                    )}
+                    {step.approverType === 'specific_user' && (
+                      <select aria-label="特定ユーザー" value={step.approverUserId ?? ''}
+                        onChange={e => onWorkflowChange(prev => prev.map((s, i) => i === idx ? { ...s, approverUserId: e.target.value } : s))}
+                        className="flex-1 h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
+                        <option value="">ユーザーを選択</option>
+                        {users.filter(u => u.status === 'active').map(u => <option key={u.id} value={u.id}>{u.name}</option>)}
+                      </select>
+                    )}
+                    {step.approverType === 'approval_group' && (
+                      <select aria-label="並列設定" value={step.parallelType ?? 'or'}
+                        onChange={e => onWorkflowChange(prev => prev.map((s, i) => i === idx ? { ...s, parallelType: e.target.value as 'or' | 'and' } : s))}
+                        className="h-8 px-2 bg-white border rounded-xl text-xs font-bold focus:outline-none focus:border-slate-400 transition-all">
+                        <option value="or">OR（誰か1名）</option>
+                        <option value="and">AND（全員）</option>
+                      </select>
+                    )}
+                  </div>
+                  {step.approverType === 'approval_group' && (
+                    <div className="space-y-1">
+                      <p className="text-[10px] text-slate-500 font-bold">グループメンバー</p>
+                      <div className="flex flex-wrap gap-1">
+                        {users.filter(u => u.status === 'active').map(u => {
+                          const selected = (step.approverGroupIds ?? []).includes(u.id);
+                          return (
+                            <button key={u.id} type="button"
+                              onClick={() => onWorkflowChange(prev => prev.map((s, i) => {
+                                if (i !== idx) return s;
+                                const ids = s.approverGroupIds ?? [];
+                                return { ...s, approverGroupIds: selected ? ids.filter(id => id !== u.id) : [...ids, u.id] };
+                              }))}
+                              className={cn('px-2 py-0.5 rounded-full text-[10px] font-bold transition-all border', selected ? 'bg-slate-900 text-white border-slate-900' : 'bg-white text-slate-500 border-slate-200 hover:border-slate-400')}>
+                              {u.name}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="p-6 border-t flex gap-3 shrink-0">
+          <button onClick={onClose} className="flex-1 h-10 border border-slate-200 rounded-xl text-sm font-bold text-slate-600 hover:bg-slate-50 transition-all">キャンセル</button>
+          <button onClick={onSave} disabled={!catFormName} className="flex-[2] h-10 bg-slate-900 text-white rounded-xl text-sm font-bold hover:bg-black transition-all disabled:opacity-40">
+            {editingCategory ? '変更を保存' : '追加する'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/inbox/task-detail-panel.tsx
+++ b/src/components/inbox/task-detail-panel.tsx
@@ -1,0 +1,449 @@
+'use client';
+
+import Image from 'next/image';
+import {
+  CheckCircle2,
+  Clock,
+  AlertCircle,
+  Calendar,
+  MessageSquare,
+  History,
+  ShieldCheck,
+  ChevronRight,
+  FileText,
+  Archive,
+  Copy,
+  Printer,
+  AlarmClock,
+  ArrowUpRight,
+} from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { Task, AuditLog, Delegation, User } from '@/lib/repository/types';
+import { ClientOnlyDate } from '@/components/common/client-only-date';
+import { cn } from '@/lib/utils';
+import { isMyTurn } from '@/lib/workflow-utils';
+
+interface TaskDetailPanelProps {
+  selectedTask: Task | null;
+  onClose: () => void;
+  logs: AuditLog[];
+  allUsers: User[];
+  delegations: Delegation[];
+  user: User | null;
+  isProcessing: boolean;
+  commentText: string;
+  onCommentChange: (text: string) => void;
+  now: Date;
+  onApprove: () => void;
+  onAcknowledge: () => void;
+  onReject: () => void;
+  onOpenChangeApprover: (idx: number) => void;
+  onExportPdf: () => void;
+  onAddComment: () => void;
+}
+
+export function TaskDetailPanel({
+  selectedTask,
+  onClose,
+  logs,
+  allUsers,
+  delegations,
+  user,
+  isProcessing,
+  commentText,
+  onCommentChange,
+  now,
+  onApprove,
+  onAcknowledge,
+  onReject,
+  onOpenChangeApprover,
+  onExportPdf,
+  onAddComment,
+}: TaskDetailPanelProps) {
+  const router = useRouter();
+
+  return (
+    <div className={cn(
+      "overflow-y-auto bg-white p-4 md:p-6",
+      "flex-1",
+      selectedTask
+        ? "block fixed inset-0 z-30 md:relative md:inset-auto md:z-auto animate-in slide-in-from-right-4 duration-300"
+        : "hidden md:block",
+    )}>
+      {selectedTask ? (
+        <div className="max-w-3xl mx-auto space-y-6">
+          {/* モバイル専用: 戻るボタン */}
+          <button
+            onClick={onClose}
+            className="md:hidden flex items-center gap-2 text-xs font-bold text-slate-500 hover:text-slate-900 transition-colors mb-2 -ml-1"
+          >
+            <ChevronRight className="w-4 h-4 rotate-180" />
+            一覧に戻る
+          </button>
+          {/* SLAエスカレーションバナー */}
+          {selectedTask.status !== 'completed' && new Date(selectedTask.dueDate) < now && (() => {
+            const overdueDays = Math.floor((now.getTime() - new Date(selectedTask.dueDate).getTime()) / 86400000);
+            const urgency = overdueDays >= 5 ? 'critical' : overdueDays >= 2 ? 'high' : 'medium';
+            return (
+              <div className={cn(
+                "flex items-start gap-3 px-4 py-3 rounded-2xl border animate-in fade-in duration-300",
+                urgency === 'critical' ? "bg-rose-50 border-rose-200" :
+                urgency === 'high'     ? "bg-orange-50 border-orange-200" :
+                                        "bg-amber-50 border-amber-200"
+              )}>
+                <AlarmClock className={cn(
+                  "w-4 h-4 mt-0.5 shrink-0",
+                  urgency === 'critical' ? "text-rose-600" : urgency === 'high' ? "text-orange-600" : "text-amber-600"
+                )} />
+                <div className="flex-1 min-w-0">
+                  <p className={cn(
+                    "text-xs font-black",
+                    urgency === 'critical' ? "text-rose-700" : urgency === 'high' ? "text-orange-700" : "text-amber-700"
+                  )}>
+                    SLA 超過 — {overdueDays}日経過
+                    {urgency === 'critical' && '（緊急対応が必要です）'}
+                  </p>
+                  <p className={cn(
+                    "text-[10px] font-medium mt-0.5",
+                    urgency === 'critical' ? "text-rose-700" : urgency === 'high' ? "text-orange-700" : "text-amber-700"
+                  )}>
+                    期限: <ClientOnlyDate date={selectedTask.dueDate} /> ／ 現在の担当者が未処理のため遅延しています
+                  </p>
+                </div>
+              </div>
+            );
+          })()}
+          <header className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="px-3 py-1 rounded-full bg-slate-100 border text-[10px] font-black text-slate-500 uppercase tracking-widest">
+                  {selectedTask.category}
+                </span>
+                {selectedTask.taskType === 'circulation' && (
+                  <span className="px-2 py-1 rounded-full bg-teal-50 border border-teal-200 text-[10px] font-black text-teal-600 uppercase tracking-widest">
+                    回覧
+                  </span>
+                )}
+                <span className="text-[10px] font-bold text-slate-500">ID: {selectedTask.id}</span>
+              </div>
+              <button
+                onClick={onExportPdf}
+                title="稟議書をPDFで出力"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-black text-slate-500 border border-slate-200 rounded-lg hover:bg-slate-50 hover:border-slate-400 transition-all uppercase tracking-widest"
+                aria-label="稟議書PDF出力"
+              >
+                <Printer className="w-3.5 h-3.5" />
+                稟議書
+              </button>
+            </div>
+            <h1 className="text-xl font-black tracking-tight text-[#191714] leading-tight">
+              {selectedTask.title}
+            </h1>
+            <div className="flex items-center gap-6 py-2 border-y border-slate-100">
+              <div className="space-y-1">
+                <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">申請者</div>
+                <div className="flex items-center gap-2">
+                  <div className="w-6 h-6 rounded-lg bg-slate-100 flex items-center justify-center text-xs font-bold">U</div>
+                  <span className="text-xs font-bold text-[#191714]">User {selectedTask.requesterId.split('_').pop()}</span>
+                </div>
+              </div>
+              <div className="space-y-1">
+                <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">期限 (SLA)</div>
+                <div className="flex items-center gap-2">
+                  <Calendar className="w-4 h-4 text-slate-500" />
+                  <span className="text-xs font-bold text-[#191714]"><ClientOnlyDate date={selectedTask.dueDate} /></span>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <section className="space-y-4">
+            <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
+              <FileText className="w-4 h-4" />
+              依頼内容の詳細
+            </h3>
+            <div className="text-sm font-medium text-slate-600 leading-relaxed bg-slate-50/50 p-6 rounded-2xl border border-slate-100">
+              {selectedTask.description || <span className="text-slate-500 italic">追加の説明はありません。</span>}
+            </div>
+            {selectedTask.customData && Object.keys(selectedTask.customData).length > 0 && (
+              <div className="mt-6 space-y-4 bg-white p-6 rounded-2xl border border-slate-200">
+                <h4 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-4">追加フォーム入力内容</h4>
+                <div className="grid grid-cols-2 gap-y-4">
+                  {Object.entries(selectedTask.customData).map(([key, value]) => (
+                    <div key={key} className="space-y-1">
+                      <div className="text-[10px] font-bold text-slate-500 uppercase">{key}</div>
+                      <div className="text-sm font-bold text-[#191714]">{value as string}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* Approval Route Visual */}
+          <section className="space-y-6">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
+                <ShieldCheck className="w-4 h-4" />
+                現在の承認ステータス
+              </h3>
+              {selectedTask.approvalRoute && selectedTask.approvalRoute.length > 0 && (() => {
+                const completed = selectedTask.approvalRoute.filter(s => s.status === 'approved').length;
+                const total = selectedTask.approvalRoute.length;
+                return (
+                  <span className="bg-slate-100 text-slate-700 px-3 py-1 rounded-full text-xs font-bold">
+                    {completed} / {total} ステップ完了
+                  </span>
+                );
+              })()}
+            </div>
+            {(() => {
+              const activeStageSteps = selectedTask.approvalRoute.filter(
+                s => s.status === 'pending' && s.parallelType === 'and'
+              );
+              if (activeStageSteps.length < 2) return null;
+              const names = activeStageSteps.map(s => s.userName).join('・');
+              return (
+                <div className="flex items-center gap-2 px-4 py-2.5 bg-violet-50 border border-violet-100 rounded-2xl">
+                  <span className="text-[10px] font-black text-violet-500 uppercase tracking-widest">AND 並列</span>
+                  <span className="text-xs font-bold text-violet-700">{names} が同時に承認待ちです（全員の承認が必要）</span>
+                </div>
+              );
+            })()}
+            <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+              {selectedTask.approvalRoute?.map((step, idx) => {
+                const isDelegated = !!step.delegatedBy;
+                const delegateUser = isDelegated ? allUsers.find(u => u.id === step.delegatedBy) : null;
+                const isParallel = step.parallelType !== undefined;
+                const stepLabel =
+                  selectedTask.taskType === 'circulation'
+                    ? step.status === 'approved' ? '確認済' : '未確認'
+                    : step.status === 'approved' ? '承認済' : step.status === 'rejected' ? '差し戻し' : '待機中';
+                return (
+                  <div key={idx} className="relative p-4 bg-white border border-slate-200 rounded-2xl hover:border-slate-400 transition-all notion-shadow group">
+                    {isParallel && (
+                      <span className={cn(
+                        "absolute top-2 left-3 text-[8px] font-black uppercase tracking-widest px-1.5 py-0.5 rounded-full border",
+                        step.parallelType === 'and' ? "bg-violet-50 text-violet-500 border-violet-100" : "bg-amber-50 text-amber-500 border-amber-100",
+                      )}>
+                        {step.parallelType === 'and' ? 'AND' : 'OR'}
+                      </span>
+                    )}
+                    <div className="absolute top-3 right-3">
+                      {step.status === 'approved' ? (
+                        <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+                      ) : step.status === 'rejected' ? (
+                        <AlertCircle className="w-4 h-4 text-rose-400" />
+                      ) : (
+                        <Clock className="w-4 h-4 text-slate-200" />
+                      )}
+                    </div>
+                    {step.avatar
+                      ? <Image src={step.avatar} width={40} height={40} alt={step.userName} className="w-10 h-10 rounded-xl bg-slate-100 mb-3 mt-2" />
+                      : <div className="w-10 h-10 rounded-xl bg-slate-100 mb-3 mt-2" />
+                    }
+                    <div className="text-[9px] font-bold text-slate-500 uppercase tracking-widest leading-none mb-1">{step.position}</div>
+                    <div className="text-xs font-bold text-[#191714]">{step.userName}</div>
+                    {isDelegated && delegateUser && (
+                      <div className="text-[9px] font-bold text-violet-500 mt-0.5">代理: {delegateUser.name}</div>
+                    )}
+                    <div className="mt-2 flex items-center gap-1.5 flex-wrap">
+                      <span className={cn(
+                        "text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border",
+                        step.status === 'approved' ? "bg-emerald-50 text-emerald-600 border-emerald-100" :
+                        step.status === 'rejected' ? "bg-rose-50 text-rose-500 border-rose-100" :
+                        "bg-slate-50 text-slate-500 border-slate-100"
+                      )}>
+                        {stepLabel}
+                      </span>
+                      {step.status === 'pending' && (
+                        <button
+                          onClick={() => onOpenChangeApprover(idx)}
+                          className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border border-slate-200 text-slate-500 hover:border-blue-400 hover:text-blue-600 hover:bg-blue-50 transition-all"
+                          aria-label={`${step.userName}の承認者を変更`}
+                        >
+                          変更
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {selectedTask.ccRoute && selectedTask.ccRoute.length > 0 && (
+              <div className="pt-2 animate-in fade-in duration-500">
+                <div className="flex items-center gap-2 mb-3">
+                  <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">CC（共有先）</div>
+                  <div className="h-px flex-1 bg-slate-100" />
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {selectedTask.ccRoute.map((cc, idx) => (
+                    <div key={idx} className="flex items-center gap-2 pl-1 pr-3 py-1 bg-slate-50 border border-slate-100 rounded-full hover:bg-slate-100 transition-colors group cursor-default">
+                      {cc.avatar
+                        ? <Image src={cc.avatar} width={20} height={20} alt={cc.userName} className="w-5 h-5 rounded-full bg-slate-200" />
+                        : <div className="w-5 h-5 rounded-full bg-slate-200" />
+                      }
+                      <div className="flex flex-col">
+                        <span className="text-[10px] font-bold text-[#191714] leading-tight">{cc.userName}</span>
+                        <span className="text-[8px] font-medium text-slate-500 leading-tight uppercase tracking-tighter">{cc.position}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* Audit Logs (Timeline) */}
+          <section className="space-y-6">
+            <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
+              <History className="w-4 h-4" />
+              アクティビティ履歴
+            </h3>
+            <div className="space-y-8 border-l-2 border-slate-100 pl-6 ml-2 relative">
+              {logs.length > 0 ? logs.map((log, idx) => {
+                const getActionTheme = (action: string) => {
+                  switch (action) {
+                    case 'submit': return { label: '提出', color: 'bg-blue-600', icon: <ArrowUpRight className="w-3 h-3 text-white" /> };
+                    case 'approve': return { label: '承認', color: 'bg-emerald-500', icon: <CheckCircle2 className="w-3 h-3 text-white" /> };
+                    case 'reject': return { label: '却下', color: 'bg-rose-500', icon: <AlertCircle className="w-3 h-3 text-white" /> };
+                    case 'reassign': return { label: '担当者変更', color: 'bg-amber-500', icon: <History className="w-3 h-3 text-white" /> };
+                    case 'comment': return { label: 'コメント', color: 'bg-slate-400', icon: <MessageSquare className="w-3 h-3 text-white" /> };
+                    default: return { label: action, color: 'bg-slate-900', icon: <FileText className="w-3 h-3 text-white" /> };
+                  }
+                };
+                const theme = getActionTheme(log.action);
+                return (
+                  <div key={log.id} className="relative animate-in fade-in slide-in-from-left-2 duration-300" style={{ animationDelay: `${idx * 100}ms` }}>
+                    <div className={cn(
+                      "absolute -left-[35px] top-0 w-6 h-6 rounded-full flex items-center justify-center ring-4 ring-white shadow-sm",
+                      theme.color
+                    )}>
+                      {theme.icon}
+                    </div>
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs font-black text-[#191714]">{log.userName}</span>
+                          <span className={cn(
+                            "px-1.5 py-0.5 rounded text-[8px] font-black uppercase tracking-tight text-white",
+                            theme.color
+                          )}>
+                            {theme.label}
+                          </span>
+                        </div>
+                        <div className="text-[10px] font-bold text-slate-500">
+                          <ClientOnlyDate date={log.timestamp} showTime />
+                        </div>
+                      </div>
+                      <div className="p-4 bg-slate-50/50 border border-slate-100 rounded-2xl text-xs font-medium text-slate-600 leading-relaxed">
+                        {log.comment || `${theme.label}されました。`}
+                      </div>
+                    </div>
+                  </div>
+                );
+              }) : (
+                <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest italic py-4">履歴データはまだありません</div>
+              )}
+            </div>
+          </section>
+
+          {/* In-App Messaging (Comments) */}
+          <section className="space-y-6 pt-4 border-t">
+            <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest flex items-center gap-2">
+              <MessageSquare className="w-4 h-4" />
+              連絡・コメントを追加
+            </h3>
+            <div className="flex gap-4">
+              <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center text-xs font-bold shrink-0">
+                {user?.avatar ? <Image src={user.avatar} width={40} height={40} className="w-full h-full rounded-full object-cover" alt="avatar" /> : 'U'}
+              </div>
+              <div className="flex-1 space-y-3">
+                <textarea
+                  rows={3}
+                  aria-label="コメントを入力"
+                  placeholder="申請内容に関する質問や連絡事項を入力してください..."
+                  className="w-full p-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm font-medium focus:outline-none focus:ring-2 focus:ring-slate-900/10 focus:border-slate-900 transition-all resize-none"
+                  value={commentText}
+                  onChange={(e) => onCommentChange(e.target.value)}
+                />
+                <div className="flex justify-end">
+                  <button
+                    onClick={onAddComment}
+                    disabled={!commentText.trim()}
+                    className="px-6 py-2.5 bg-[#191714] text-white rounded-xl text-xs font-bold hover:bg-black transition-all disabled:opacity-30 disabled:pointer-events-none"
+                  >
+                    コメントを送信する
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <footer className="pt-10 space-y-3">
+            {user && (() => {
+              const delegation = delegations.find(d =>
+                d.delegateId === user.id && d.isActive &&
+                selectedTask.approvalRoute.some(s => s.userId === d.delegatorId && s.status === 'pending')
+              );
+              if (!delegation) return null;
+              const delegatorName = allUsers.find(u => u.id === delegation.delegatorId)?.name ?? delegation.delegatorId;
+              return (
+                <div className="flex items-center gap-2 px-4 py-2 bg-violet-50 border border-violet-100 rounded-2xl">
+                  <span className="text-[10px] font-black text-violet-500 uppercase tracking-widest shrink-0">代決</span>
+                  <span className="text-xs font-bold text-violet-700"><span className="text-violet-900">{delegatorName}</span> の代理として承認します</span>
+                </div>
+              );
+            })()}
+            <div className="flex items-center gap-4">
+              {selectedTask.status === 'completed' ? (
+                <button
+                  onClick={() => router.push(`/request?reuseTaskId=${selectedTask.id}`)}
+                  className="flex-1 py-4 bg-slate-900 mx-auto text-white rounded-2xl font-bold flex items-center justify-center gap-2 hover:bg-black transition-all hover:shadow-xl hover:-translate-y-1"
+                >
+                  <Copy className="w-5 h-5" />
+                  再利用して申請
+                </button>
+              ) : selectedTask.taskType === 'circulation' && user && selectedTask.approvalRoute.some(s => s.userId === user.id && s.status === 'pending') ? (
+                <button
+                  onClick={onAcknowledge}
+                  disabled={isProcessing}
+                  className="flex-1 py-4 bg-emerald-600 text-white rounded-2xl font-bold hover:bg-emerald-700 transition-all hover:shadow-xl hover:-translate-y-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  確認済みにする
+                </button>
+              ) : user && isMyTurn(selectedTask, user.id, delegations) ? (
+                <>
+                  <button
+                    onClick={onApprove}
+                    disabled={isProcessing}
+                    className="flex-1 py-4 bg-slate-900 text-white rounded-2xl font-bold hover:bg-black transition-all hover:shadow-xl hover:-translate-y-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isProcessing ? '処理中...' : '承認・受理する'}
+                  </button>
+                  <button
+                    onClick={onReject}
+                    disabled={isProcessing}
+                    className="px-8 py-4 bg-white border border-slate-200 text-rose-600 rounded-2xl font-bold hover:bg-rose-50 hover:border-rose-200 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    差し戻し
+                  </button>
+                </>
+              ) : (
+                <div className="flex-1 py-4 text-center text-sm font-bold text-slate-500 border border-dashed rounded-2xl">
+                  現在あなたの対応番ではありません
+                </div>
+              )}
+            </div>
+          </footer>
+        </div>
+      ) : (
+        <div className="h-full flex flex-col items-center justify-center text-slate-500">
+          <Archive className="w-16 h-16 opacity-10 mb-4" />
+          <p className="text-sm font-bold uppercase tracking-widest opacity-30">依頼を選択してください</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `src/app/admin/page.tsx` から `CategoryFormModal` を抽出し `src/components/admin/category-form-modal.tsx` へ分離
- `src/app/inbox/page.tsx` から `TaskDetailPanel` を抽出し `src/components/inbox/task-detail-panel.tsx` へ分離
- `next/dynamic` で両コンポーネントを lazy import し、初期バンドルサイズを削減
- admin ページ: 1,648行 → 1,406行、inbox ページ: 1,036行 → 660行

Closes #37

## Test plan

- [ ] `npm run typecheck` がエラーなしで通ること
- [ ] `npm run lint` がエラーなしで通ること
- [ ] `npm run build` が成功すること
- [ ] `/admin` でカテゴリ追加モーダルが正常に開閉すること
- [ ] `/inbox` でタスク詳細パネルが正常に表示されること
- [ ] ローディングスピナーが表示されてからコンテンツが描画されること