### PR TITLE
perf(org): OrgNode 再帰描画に React.memo を適用

### DIFF
--- a/src/components/organization/org-node.tsx
+++ b/src/components/organization/org-node.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import Image from 'next/image';
 import { ChevronRight, ChevronDown, Building2, Shield, User as UserIcon } from 'lucide-react';
 import { OrganizationUnit, User } from '@/lib/repository/types';
@@ -16,10 +16,7 @@ interface OrgNodeProps {
   onUserClick?: (user: User) => void;
 }
 
-/**
- * 組織図の階層構造を再帰的にレンダリングするコンポーネント
- */
-export function OrgNode({
+export const OrgNode = memo(function OrgNode({
   unit,
   allUnits,
   usersInUnit,
@@ -167,4 +164,4 @@ export function OrgNode({
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary

- `OrgNode` コンポーネントを `React.memo` でラップし、props が変化しない子ノードの不要な再レンダリングを防止
- `memo` を React import に追加
- `export function OrgNode` → `export const OrgNode = memo(function OrgNode(...))` に変更

Closes #39

## Test plan

- [ ] typecheck・lint がエラーなしで通ること
- [ ] `/organization` ページで組織図の表示・展開が正常に動作すること
- [ ] ユーザークリックでの詳細表示が正常に動作すること