### PR TITLE
chore(docker): Dockerfile + .dockerignore + next.config.ts standalone 出力設定（GCP-A1〜A3）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.next
+node_modules
+.env*
+e2e/
+playwright-report/
+test-results/
+*.md
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:20-alpine AS base
+
+FROM base AS builder
+WORKDIR /app
+COPY package*.json .npmrc ./
+RUN npm ci
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=8080
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 8080
+
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 });
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'api.dicebear.com' },


### PR DESCRIPTION
## Summary

- \`Dockerfile\` を追加（Node.js 20 alpine マルチステージビルド: builder → runner）
- \`.dockerignore\` を追加（node_modules, .next, .env*, e2e/ 等を除外）
- \`next.config.ts\` に \`output: 'standalone'\` を追加（Docker イメージ軽量化）

Closes #47

## Test plan

- [ ] \`npm run typecheck\` がエラーなしで通過する
- [ ] \`npm run lint\` がエラーなしで通過する
- [ ] CI（build / test / audit）が全て pass する