### PR TITLE
chore(gcp): cloudbuild.yaml + .env.production.example 追加（GCP-A4〜A5）

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,6 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://<project-id>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+
+# Data provider: "supabase" for production, "mock" for local development
+NEXT_PUBLIC_DATA_PROVIDER=supabase

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.production.example
 
 # vercel
 .vercel

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -172,9 +172,9 @@
 
 | # | 内容 | 対象ファイル | ステータス |
 |---|------|------------|----------|
-| GCP-A1 | Dockerfile 作成（Node.js 20 alpine、マルチステージビルド） | `Dockerfile`（新規） | ⬜ |
-| GCP-A2 | .dockerignore 作成（`node_modules`, `.next`, `.env*`, `e2e/` 等を除外） | `.dockerignore`（新規） | ⬜ |
-| GCP-A3 | `next.config.ts` に `output: 'standalone'` 追加（Docker イメージ軽量化） | `next.config.ts` | ⬜ |
+| GCP-A1 | Dockerfile 作成（Node.js 20 alpine、マルチステージビルド） | `Dockerfile`（新規） | ✅ |
+| GCP-A2 | .dockerignore 作成（`node_modules`, `.next`, `.env*`, `e2e/` 等を除外） | `.dockerignore`（新規） | ✅ |
+| GCP-A3 | `next.config.ts` に `output: 'standalone'` 追加（Docker イメージ軽量化） | `next.config.ts` | ✅ |
 | GCP-A4 | `cloudbuild.yaml` 作成（Docker ビルド → Artifact Registry プッシュ → Cloud Run デプロイ） | `cloudbuild.yaml`（新規） | ⬜ |
 | GCP-A5 | `.env.production.example` 作成（必要な環境変数テンプレート） | `.env.production.example`（新規） | ⬜ |
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,30 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/task-flow/app:$COMMIT_SHA'
+      - '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/task-flow/app:$COMMIT_SHA'
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'task-flow'
+      - '--image=asia-northeast1-docker.pkg.dev/$PROJECT_ID/task-flow/app:$COMMIT_SHA'
+      - '--region=asia-northeast1'
+      - '--min-instances=1'
+      - '--max-instances=10'
+      - '--memory=512Mi'
+      - '--port=8080'
+      - '--allow-unauthenticated'
+      - '--update-secrets=NEXT_PUBLIC_SUPABASE_URL=NEXT_PUBLIC_SUPABASE_URL:latest,NEXT_PUBLIC_SUPABASE_ANON_KEY=NEXT_PUBLIC_SUPABASE_ANON_KEY:latest,NEXT_PUBLIC_DATA_PROVIDER=NEXT_PUBLIC_DATA_PROVIDER:latest'
+
+images:
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/task-flow/app:$COMMIT_SHA'


### PR DESCRIPTION
## Summary

- `cloudbuild.yaml` を追加（Docker ビルド → Artifact Registry プッシュ → Cloud Run デプロイの3ステップ CD パイプライン）
- `.env.production.example` を追加（本番環境変数テンプレート）
- `.gitignore` に `!.env.production.example` 例外を追加（`.env*` パターンからの除外防止）

Closes #49

## Test plan

- [ ] `npm run typecheck` がエラーなしで通過する
- [ ] `npm run lint` がエラーなしで通過する
- [ ] CI（build / test / audit）が全て pass する