### PR TITLE
fix(mock/admin): 新規申請カテゴリー空欄バグとユーザー追加一覧非表示バグを修正

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -175,8 +175,8 @@
 | GCP-A1 | Dockerfile 作成（Node.js 20 alpine、マルチステージビルド） | `Dockerfile`（新規） | ✅ |
 | GCP-A2 | .dockerignore 作成（`node_modules`, `.next`, `.env*`, `e2e/` 等を除外） | `.dockerignore`（新規） | ✅ |
 | GCP-A3 | `next.config.ts` に `output: 'standalone'` 追加（Docker イメージ軽量化） | `next.config.ts` | ✅ |
-| GCP-A4 | `cloudbuild.yaml` 作成（Docker ビルド → Artifact Registry プッシュ → Cloud Run デプロイ） | `cloudbuild.yaml`（新規） | ⬜ |
-| GCP-A5 | `.env.production.example` 作成（必要な環境変数テンプレート） | `.env.production.example`（新規） | ⬜ |
+| GCP-A4 | `cloudbuild.yaml` 作成（Docker ビルド → Artifact Registry プッシュ → Cloud Run デプロイ） | `cloudbuild.yaml`（新規） | ✅ |
+| GCP-A5 | `.env.production.example` 作成（必要な環境変数テンプレート） | `.env.production.example`（新規） | ✅ |
 
 ---
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -40,7 +40,7 @@ export default function AdminSettings() {
     ]);
     setOrgUnits(units);
     setCategories(cats);
-    setUsers(allUsers.slice(0, 50));
+    setUsers(allUsers);
     setLogs(allLogs);
     setTasks(allTasks);
     setDelegations(allDelegations);

--- a/src/components/admin/admin-org-section.tsx
+++ b/src/components/admin/admin-org-section.tsx
@@ -33,6 +33,7 @@ export function AdminOrgSection({ users, orgUnits, onRefetch }: AdminOrgSectionP
   const [newUserEmail, setNewUserEmail] = useState('');
   const [newUserPosition, setNewUserPosition] = useState('Member');
   const [newUserOrgUnit, setNewUserOrgUnit] = useState('');
+  const [addUserToast, setAddUserToast] = useState<string | null>(null);
 
   // User row menu
   const [userMenuTargetId, setUserMenuTargetId] = useState<string | null>(null);
@@ -105,6 +106,7 @@ export function AdminOrgSection({ users, orgUnits, onRefetch }: AdminOrgSectionP
   const handleAddUser = async () => {
     if (!newUserName || !newUserEmail) return;
     const provider = getDataProvider();
+    const addedName = newUserName;
     await provider.createUser({
       name: newUserName, email: newUserEmail, role: 'user',
       position: newUserPosition,
@@ -115,6 +117,8 @@ export function AdminOrgSection({ users, orgUnits, onRefetch }: AdminOrgSectionP
     setShowAddUserModal(false);
     setNewUserName(''); setNewUserEmail(''); setNewUserPosition('Member'); setNewUserOrgUnit('');
     await onRefetch();
+    setAddUserToast(`${addedName} を追加しました`);
+    setTimeout(() => setAddUserToast(null), 3000);
   };
 
   const handleEditUser = async () => {
@@ -606,6 +610,13 @@ export function AdminOrgSection({ users, orgUnits, onRefetch }: AdminOrgSectionP
               </div>
             </div>
           </div>
+        </div>
+      )}
+      {/* ユーザー追加成功トースト */}
+      {addUserToast && (
+        <div className="fixed bottom-6 right-6 z-50 flex items-center gap-3 bg-emerald-600 text-white px-5 py-3 rounded-2xl shadow-lg animate-in slide-in-from-bottom-4 duration-300">
+          <CheckCircle2 className="w-5 h-5 shrink-0" />
+          <span className="text-sm font-bold">{addUserToast}</span>
         </div>
       )}
     </div>

--- a/src/lib/repository/mock-provider.ts
+++ b/src/lib/repository/mock-provider.ts
@@ -200,6 +200,7 @@ export class MockDataProvider implements DataProvider {
       id: `task_${Math.random().toString(36).substr(2, 9)}`,
       statusId: 'status_todo',
       status: 'todo',
+      category: category?.name || '',
       createdAt: createdAt.toISOString(),
       updatedAt: createdAt.toISOString(),
       dueDate: dueDate.toISOString(),


### PR DESCRIPTION
## Summary

- **B-1:** `mock-provider.ts` の `createTask()` に `category: category?.name || ''` を追加し、新規申請のカテゴリー名がCSV・PDFに正しく出力されるよう修正
- **B-4a:** `admin/page.tsx` の `allUsers.slice(0, 50)` を撤廃し、管理者画面でユーザー追加後に一覧に表示されるよう修正
- **B-4b:** `admin-org-section.tsx` の `handleAddUser()` にトースト通知を追加し、ユーザー追加完了を明示的にフィードバック

Closes #52

## Test plan

- [ ] 新規申請を作成し、CSVエクスポートのカテゴリー列に正しいカテゴリー名が表示されること
- [ ] 同申請の承認書PDFにカテゴリー欄が正しく表示されること
- [ ] 管理者画面でユーザーを追加後、一覧に新規ユーザーが表示されること
- [ ] ユーザー追加後3秒間、右下にトースト通知が表示されること