### PR TITLE
fix(inbox): 代決設定後に代理承認者の受信トレイに委任タスクが表示されない問題を修正

### DIFF
--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -176,6 +176,7 @@ export default function RequestInbox() {
         user={user}
         categories={categories}
         allUsers={allUsers}
+        delegations={delegations}
         now={now}
         onSelectTask={setSelectedTask}
       />

--- a/src/components/inbox/task-list-panel.tsx
+++ b/src/components/inbox/task-list-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Search, Filter, MoreHorizontal, Download } from 'lucide-react';
-import { Task, Category, User } from '@/lib/repository/types';
+import { Task, Category, User, Delegation } from '@/lib/repository/types';
 import { ClientOnlyDate } from '@/components/common/client-only-date';
 import { downloadTasksCsv } from '@/lib/export/approval-pdf';
 import { cn } from '@/lib/utils';
@@ -13,6 +13,7 @@ interface TaskListPanelProps {
   user: User | null;
   categories: Category[];
   allUsers: User[];
+  delegations: Delegation[];
   now: Date;
   onSelectTask: (task: Task) => void;
 }
@@ -23,6 +24,7 @@ export function TaskListPanel({
   user,
   categories,
   allUsers,
+  delegations,
   now,
   onSelectTask,
 }: TaskListPanelProps) {
@@ -41,9 +43,21 @@ export function TaskListPanel({
     let baseTasks = tasks;
     const isAdmin = user.role === 'admin' || user.departmentId === 'dept_admin';
 
+    // 自分が代理承認者である有効な代決の委任元IDリスト
+    const activeDelegatorIds = delegations
+      .filter(d =>
+        d.delegateId === user.id &&
+        d.isActive &&
+        new Date(d.startDate) <= now &&
+        (!d.endDate || new Date(d.endDate) >= now)
+      )
+      .map(d => d.delegatorId);
+
     if (!isAdmin) {
       baseTasks = tasks.filter(t =>
-        t.approvalRoute.some(step => step.userId === user.id)
+        t.approvalRoute.some(step => step.userId === user.id) ||
+        (activeDelegatorIds.length > 0 &&
+          t.approvalRoute.some(step => activeDelegatorIds.includes(step.userId) && step.status === 'pending'))
       );
     }
 
@@ -53,7 +67,10 @@ export function TaskListPanel({
       if (filter === 'overdue') return isOverdue;
       if (filter === 'completed') return t.status === 'completed';
       if (!isAdmin) {
-        if (filter === 'todo') return t.currentApproverId === user.id && !isOverdue;
+        if (filter === 'todo') {
+          const isDelegateTodo = activeDelegatorIds.includes(t.currentApproverId ?? '');
+          return (t.currentApproverId === user.id || isDelegateTodo) && !isOverdue;
+        }
         if (filter === 'in_progress') {
           const myStepIndex = t.approvalRoute.findIndex(s => s.userId === user.id);
           const myStep = t.approvalRoute[myStepIndex];


### PR DESCRIPTION
## Summary

- `TaskListPanel` に `delegations: Delegation[]` prop を追加し、フィルタロジックで代決を考慮するよう修正
- 有効な代決（`isActive=true` かつ `startDate〜endDate` 期間内）の委任元（`delegatorId`）が承認ステップに含まれるタスクを代理承認者の受信トレイに表示
- `filter === 'todo'` の条件にも代決チェックを追加（`currentApproverId` が `delegatorId` のタスクも「未対応」として表示）
- `inbox/page.tsx` の `<TaskListPanel>` に `delegations={delegations}` を渡すよう修正

Closes #54

## Test plan

- [ ] 代決設定（代理承認者=中村 浩、委任元=高橋 健二）後、中村 浩の受信トレイに高橋 健二宛の申請が表示されること
- [ ] 代決の有効期間外（endDate 経過後）には表示されないこと
- [ ] 代決を revoke（isActive=false）後には表示されなくなること
- [ ] 代理承認者が「承認・受理する」を押すと元の承認者（高橋 健二）のステップが処理されること
- [ ] 代決なしの通常ユーザーの受信トレイ表示に影響がないこと