### PR TITLE
feat(inbox): block self-approval for requester in UI and processApproval

### DIFF
--- a/src/components/inbox/task-detail-panel.tsx
+++ b/src/components/inbox/task-detail-panel.tsx
@@ -405,7 +405,7 @@ export function TaskDetailPanel({
                   <Copy className="w-5 h-5" />
                   再利用して申請
                 </button>
-              ) : selectedTask.taskType === 'circulation' && user && selectedTask.approvalRoute.some(s => s.userId === user.id && s.status === 'pending') ? (
+              ) : selectedTask.taskType === 'circulation' && user && user.id !== selectedTask.requesterId && selectedTask.approvalRoute.some(s => s.userId === user.id && s.status === 'pending') ? (
                 <button
                   onClick={onAcknowledge}
                   disabled={isProcessing}
@@ -413,7 +413,7 @@ export function TaskDetailPanel({
                 >
                   確認済みにする
                 </button>
-              ) : user && isMyTurn(selectedTask, user.id, delegations) ? (
+              ) : user && user.id !== selectedTask.requesterId && isMyTurn(selectedTask, user.id, delegations) ? (
                 <>
                   <button
                     onClick={onApprove}

--- a/src/lib/repository/mock-provider.ts
+++ b/src/lib/repository/mock-provider.ts
@@ -240,6 +240,8 @@ export class MockDataProvider implements DataProvider {
     const task = await this.getTaskById(taskId);
     if (!task) throw new Error('Task not found');
 
+    if (task.requesterId === userId) throw new Error('自己承認は禁止されています');
+
     // ── 代決チェック: userId が delegate の場合、delegator のステップを処理 ──
     let stepIndex = task.approvalRoute.findIndex(s => s.userId === userId && s.status === 'pending');
     let delegatedBy: string | undefined;


### PR DESCRIPTION
## Summary

- `task-detail-panel.tsx` の「承認・受理する」「差し戻し」「確認済みにする」ボタン表示条件に `user.id !== selectedTask.requesterId` チェックを追加
- `mock-provider.ts` の `processApproval()` 冒頭に申請者本人によるアクション禁止チェック（`task.requesterId === userId` でエラースロー）を追加
- これにより UI・ロジック両層で自己承認を防止

Closes #57

## Test plan

- [ ] 申請者本人でログインし、自分の申請を受信トレイで選択したとき「承認・受理する」「差し戻し」ボタンが表示されないこと
- [ ] 回覧タスクで申請者本人に「確認済みにする」ボタンが表示されないこと
- [ ] 別ユーザー（承認者）でログインした場合は引き続きボタンが表示されること
- [ ] 代決ユーザーが申請者以外の場合は正常に承認できること