### PR TITLE
fix(request): disable submit button until required custom fields are filled

### DIFF
--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -95,6 +95,11 @@ function RequestFormContent() {
   // フォームバリデーション
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
+  const requiredFieldsFilled =
+    selectedCategory?.customFields
+      ?.filter(f => f.required)
+      .every(f => String(customData[f.label] ?? '').trim() !== '') ?? true;
+
   // 金額閾値警告
   const [amountWarnings, setAmountWarnings] = useState<Array<{ rule: AmountRule; amount: number }>>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -971,7 +976,7 @@ function RequestFormContent() {
 
             <button 
               type="submit"
-              disabled={!selectedCategory || !title}
+              disabled={!selectedCategory || !title.trim() || !requiredFieldsFilled}
               className="w-full flex items-center justify-center gap-2 py-4 bg-[#191714] text-white rounded-2xl font-bold hover:bg-black transition-all hover:shadow-2xl hover:-translate-y-1 disabled:opacity-20 disabled:pointer-events-none"
             >
               <Send className="w-4 h-4" />


### PR DESCRIPTION
## Summary

- 申請フォームで必須カスタムフィールドが未入力の場合、送信ボタンを無効化するよう修正
- `requiredFieldsFilled` 派生値を追加し、submit ボタンの `disabled` 条件に組み込み
- バリデーションは送信時の `validateAllFields()` も引き続き機能するため二重チェック済み

Closes #58

## Test plan

- [ ] カテゴリ選択後、必須カスタムフィールドが空の状態で送信ボタンが無効化されることを確認
- [ ] 必須フィールドをすべて入力すると送信ボタンが活性化することを確認
- [ ] 必須でないフィールドが空でも送信ボタンが活性化することを確認
- [ ] タイトルが空の場合も送信ボタンが無効のままであることを確認